### PR TITLE
Add player skill definition support

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/client/config/skill/ClientSkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/config/skill/ClientSkillDefinitionConfig.java
@@ -1,20 +1,23 @@
 package net.puffish.skillsmod.client.config.skill;
 
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import net.puffish.skillsmod.client.config.ClientFrameConfig;
 import net.puffish.skillsmod.client.config.ClientIconConfig;
 
 public record ClientSkillDefinitionConfig(
-		String id,
-		Text title,
-		Text description,
-		Text extraDescription,
-		ClientIconConfig icon,
-		ClientFrameConfig frame,
-		float size,
-		int cost,
-		int requiredSkills,
-		int requiredPoints,
-		int requiredSpentPoints,
-		int requiredExclusions
+                String id,
+                Identifier type,
+                int maxLevels,
+                java.util.List<Text> descriptions,
+                java.util.List<Text> extraDescriptions,
+                Text title,
+                ClientIconConfig icon,
+                ClientFrameConfig frame,
+                float size,
+                int cost,
+                int requiredSkills,
+                int requiredPoints,
+                int requiredSpentPoints,
+                int requiredExclusions
 ) { }

--- a/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
@@ -656,16 +656,18 @@ public class SkillsScreen extends Screen {
 
 				var lines = new ArrayList<OrderedText>();
 				lines.add(definition.title().asOrderedText());
-				lines.addAll(Tooltip.wrapLines(client, Texts.setStyleIfAbsent(
-						definition.description().copy(),
-						Style.EMPTY.withFormatting(Formatting.GRAY)
-				)));
-				if (Screen.hasShiftDown()) {
-					lines.addAll(Tooltip.wrapLines(client, Texts.setStyleIfAbsent(
-							definition.extraDescription().copy(),
-							Style.EMPTY.withFormatting(Formatting.GRAY)
-					)));
-				}
+                                var desc = definition.descriptions().isEmpty() ? Text.empty() : definition.descriptions().get(0).copy();
+                                lines.addAll(Tooltip.wrapLines(client, Texts.setStyleIfAbsent(
+                                                desc,
+                                                Style.EMPTY.withFormatting(Formatting.GRAY)
+                                )));
+                                if (Screen.hasShiftDown()) {
+                                        var extraDesc = definition.extraDescriptions().isEmpty() ? Text.empty() : definition.extraDescriptions().get(0).copy();
+                                        lines.addAll(Tooltip.wrapLines(client, Texts.setStyleIfAbsent(
+                                                        extraDesc,
+                                                        Style.EMPTY.withFormatting(Formatting.GRAY)
+                                        )));
+                                }
 				if (client.options.advancedItemTooltips) {
 					lines.add(Text.literal(hoveredSkill.id()).formatted(Formatting.DARK_GRAY).asOrderedText());
 				}

--- a/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/ShowCategoryInPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/ShowCategoryInPacket.java
@@ -102,28 +102,32 @@ public class ShowCategoryInPacket implements InPacket {
 		);
 	}
 
-	public static ClientSkillDefinitionConfig readDefinition(PacketByteBuf buf) {
-		var id = buf.readString();
-		var title = buf.readText();
-		var description = buf.readText();
-		var extraDescription = buf.readText();
-		var frame = readFrameIcon(buf);
-		var icon = readSkillIcon(buf);
-		var size = buf.readFloat();
-		var cost = buf.readInt();
-		var requiredSkills = buf.readInt();
-		var requiredPoints = buf.readInt();
-		var requiredSpentPoints = buf.readInt();
-		var requiredExclusions = buf.readInt();
+        public static ClientSkillDefinitionConfig readDefinition(PacketByteBuf buf) {
+                var id = buf.readString();
+                var type = buf.readIdentifier();
+                var maxLevels = buf.readInt();
+                var descriptions = buf.readList(PacketByteBuf::readText);
+                var extraDescriptions = buf.readList(PacketByteBuf::readText);
+                var title = buf.readText();
+                var frame = readFrameIcon(buf);
+                var icon = readSkillIcon(buf);
+                var size = buf.readFloat();
+                var cost = buf.readInt();
+                var requiredSkills = buf.readInt();
+                var requiredPoints = buf.readInt();
+                var requiredSpentPoints = buf.readInt();
+                var requiredExclusions = buf.readInt();
 
-		return new ClientSkillDefinitionConfig(
-				id,
-				title,
-				description,
-				extraDescription,
-				icon,
-				frame,
-				size,
+                return new ClientSkillDefinitionConfig(
+                                id,
+                                type,
+                                maxLevels,
+                                descriptions,
+                                extraDescriptions,
+                                title,
+                                icon,
+                                frame,
+                                size,
 				cost,
 				requiredSkills,
 				requiredPoints,

--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
@@ -1,6 +1,7 @@
 package net.puffish.skillsmod.config.skill;
 
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import net.puffish.skillsmod.api.config.ConfigContext;
 import net.puffish.skillsmod.api.json.BuiltinJson;
 import net.puffish.skillsmod.api.json.JsonElement;
@@ -16,13 +17,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 public record SkillDefinitionConfig(
-		String id,
-		Text title,
-		Text description,
-		Text extraDescription,
-		IconConfig icon,
-		FrameConfig frame,
-		float size,
+                String id,
+                Identifier type,
+                int maxLevels,
+                List<Text> descriptions,
+                List<Text> extraDescriptions,
+                Text title,
+                IconConfig icon,
+                FrameConfig frame,
+                float size,
 		List<SkillRewardConfig> rewards,
 		int cost,
 		int requiredSkills,
@@ -40,26 +43,52 @@ public record SkillDefinitionConfig(
 	public static Result<SkillDefinitionConfig, Problem> parse(String id, JsonObject rootObject, ConfigContext context) {
 		var problems = new ArrayList<Problem>();
 
-		var optTitle = rootObject.get("title")
-				.andThen(BuiltinJson::parseText)
-				.ifFailure(problems::add)
-				.getSuccess();
+                var optTitle = rootObject.get("title")
+                                .andThen(BuiltinJson::parseText)
+                                .ifFailure(problems::add)
+                                .getSuccess();
 
-		var description = rootObject.get("description")
-				.getSuccess() // ignore failure because this property is optional
-				.flatMap(descriptionElement -> BuiltinJson.parseText(descriptionElement)
-						.ifFailure(problems::add)
-						.getSuccess()
-				)
-				.orElseGet(Text::empty);
+                var type = rootObject.get("type")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(element -> BuiltinJson.parseIdentifier(element)
+                                                .ifFailure(problems::add)
+                                                .getSuccess())
+                                .orElse(Identifier.of("puffish_skills", "default"));
 
-		var extraDescription = rootObject.get("extra_description")
-				.getSuccess() // ignore failure because this property is optional
-				.flatMap(descriptionElement -> BuiltinJson.parseText(descriptionElement)
-						.ifFailure(problems::add)
-						.getSuccess()
-				)
-				.orElseGet(Text::empty);
+                var maxLevels = rootObject.get("max_levels")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(element -> element.getAsInt()
+                                                .ifFailure(problems::add)
+                                                .getSuccess())
+                                .orElse(1);
+
+                var descriptions = rootObject.getArray("descriptions")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(array -> array.getAsList((i, e) -> BuiltinJson.parseText(e))
+                                                .mapFailure(Problem::combine)
+                                                .ifFailure(problems::add)
+                                                .getSuccess())
+                                .orElseGet(() -> rootObject.get("description")
+                                                .getSuccess() // ignore failure because this property is optional
+                                                .flatMap(element -> BuiltinJson.parseText(element)
+                                                                .ifFailure(problems::add)
+                                                                .getSuccess())
+                                                .map(List::of)
+                                                .orElseGet(List::of));
+
+                var extraDescriptions = rootObject.getArray("extra_descriptions")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(array -> array.getAsList((i, e) -> BuiltinJson.parseText(e))
+                                                .mapFailure(Problem::combine)
+                                                .ifFailure(problems::add)
+                                                .getSuccess())
+                                .orElseGet(() -> rootObject.get("extra_description")
+                                                .getSuccess() // ignore failure because this property is optional
+                                                .flatMap(element -> BuiltinJson.parseText(element)
+                                                                .ifFailure(problems::add)
+                                                                .getSuccess())
+                                                .map(List::of)
+                                                .orElseGet(List::of));
 
 		var optIcon = rootObject.get("icon")
 				.andThen(element -> IconConfig.parse(element, context))
@@ -132,25 +161,27 @@ public record SkillDefinitionConfig(
 		// this field is generated be the editor, access it to avoid unused field error
 		rootObject.get("metadata");
 
-		if (problems.isEmpty()) {
-			return Result.success(new SkillDefinitionConfig(
-					id,
-					optTitle.orElseThrow(),
-					description,
-					extraDescription,
-					optIcon.orElseThrow(),
-					frame,
-					size,
-					rewards,
-					cost,
-					requiredSkills,
-					requiredPoints,
-					requiredSpentPoints,
-					requiredExclusions
-			));
-		} else {
-			return Result.failure(Problem.combine(problems));
-		}
+                if (problems.isEmpty()) {
+                        return Result.success(new SkillDefinitionConfig(
+                                        id,
+                                        type,
+                                        maxLevels,
+                                        descriptions,
+                                        extraDescriptions,
+                                        optTitle.orElseThrow(),
+                                        optIcon.orElseThrow(),
+                                        frame,
+                                        size,
+                                        rewards,
+                                        cost,
+                                        requiredSkills,
+                                        requiredPoints,
+                                        requiredSpentPoints,
+                                        requiredExclusions
+                        ));
+                } else {
+                        return Result.failure(Problem.combine(problems));
+                }
 	}
 
 	public void dispose(DisposeContext context) {

--- a/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ShowCategoryOutPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ShowCategoryOutPacket.java
@@ -70,20 +70,22 @@ public record ShowCategoryOutPacket(CategoryConfig category, CategoryData catego
 		buf.writeInt(general.spentPointsLimit());
 	}
 
-	public void write(PacketByteBuf buf, SkillDefinitionConfig definition) {
-		buf.writeString(definition.id());
-		buf.writeText(definition.title());
-		buf.writeText(definition.description());
-		buf.writeText(definition.extraDescription());
-		write(buf, definition.frame());
-		write(buf, definition.icon());
-		buf.writeFloat(definition.size());
-		buf.writeInt(definition.cost());
-		buf.writeInt(definition.requiredSkills());
-		buf.writeInt(definition.requiredPoints());
-		buf.writeInt(definition.requiredSpentPoints());
-		buf.writeInt(definition.requiredExclusions());
-	}
+        public void write(PacketByteBuf buf, SkillDefinitionConfig definition) {
+                buf.writeString(definition.id());
+                buf.writeIdentifier(definition.type());
+                buf.writeInt(definition.maxLevels());
+                buf.writeCollection(definition.descriptions(), PacketByteBuf::writeText);
+                buf.writeCollection(definition.extraDescriptions(), PacketByteBuf::writeText);
+                buf.writeText(definition.title());
+                write(buf, definition.frame());
+                write(buf, definition.icon());
+                buf.writeFloat(definition.size());
+                buf.writeInt(definition.cost());
+                buf.writeInt(definition.requiredSkills());
+                buf.writeInt(definition.requiredPoints());
+                buf.writeInt(definition.requiredSpentPoints());
+                buf.writeInt(definition.requiredExclusions());
+        }
 
 	public void write(PacketByteBuf buf, SkillsConfig skills) {
 		buf.writeCollection(skills.getAll(), ShowCategoryOutPacket::write);


### PR DESCRIPTION
## Summary
- allow multiple skill descriptions and extra descriptions
- support custom skill definition types and max levels
- send new fields in ShowCategory packets
- update client models and UI to show new descriptions

## Testing
- `./gradlew build -x test` *(fails: fabric-installer.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68844fa8de908327acda408f85b491d8