### PR TITLE
Add player skill definition support

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/client/config/skill/ClientSkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/config/skill/ClientSkillDefinitionConfig.java
@@ -1,14 +1,17 @@
 package net.puffish.skillsmod.client.config.skill;
 
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import net.puffish.skillsmod.client.config.ClientFrameConfig;
 import net.puffish.skillsmod.client.config.ClientIconConfig;
 
 public record ClientSkillDefinitionConfig(
 		String id,
+		Identifier type,
+		int maxLevels,
+		java.util.List<Text> descriptions,
+		java.util.List<Text> extraDescriptions,
 		Text title,
-		Text description,
-		Text extraDescription,
 		ClientIconConfig icon,
 		ClientFrameConfig frame,
 		float size,

--- a/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
@@ -656,15 +656,17 @@ public class SkillsScreen extends Screen {
 
 				var lines = new ArrayList<OrderedText>();
 				lines.add(definition.title().asOrderedText());
+				var desc = definition.descriptions().isEmpty() ? Text.empty() : definition.descriptions().get(0).copy();
 				lines.addAll(Tooltip.wrapLines(client, Texts.setStyleIfAbsent(
-						definition.description().copy(),
-						Style.EMPTY.withFormatting(Formatting.GRAY)
+				desc,
+				Style.EMPTY.withFormatting(Formatting.GRAY)
 				)));
 				if (Screen.hasShiftDown()) {
-					lines.addAll(Tooltip.wrapLines(client, Texts.setStyleIfAbsent(
-							definition.extraDescription().copy(),
-							Style.EMPTY.withFormatting(Formatting.GRAY)
-					)));
+				var extraDesc = definition.extraDescriptions().isEmpty() ? Text.empty() : definition.extraDescriptions().get(0).copy();
+				lines.addAll(Tooltip.wrapLines(client, Texts.setStyleIfAbsent(
+				extraDesc,
+				Style.EMPTY.withFormatting(Formatting.GRAY)
+				)));
 				}
 				if (client.options.advancedItemTooltips) {
 					lines.add(Text.literal(hoveredSkill.id()).formatted(Formatting.DARK_GRAY).asOrderedText());

--- a/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/ShowCategoryInPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/ShowCategoryInPacket.java
@@ -104,9 +104,11 @@ public class ShowCategoryInPacket implements InPacket {
 
 	public static ClientSkillDefinitionConfig readDefinition(PacketByteBuf buf) {
 		var id = buf.readString();
+		var type = buf.readIdentifier();
+		var maxLevels = buf.readInt();
+		var descriptions = buf.readList(PacketByteBuf::readText);
+		var extraDescriptions = buf.readList(PacketByteBuf::readText);
 		var title = buf.readText();
-		var description = buf.readText();
-		var extraDescription = buf.readText();
 		var frame = readFrameIcon(buf);
 		var icon = readSkillIcon(buf);
 		var size = buf.readFloat();
@@ -117,14 +119,16 @@ public class ShowCategoryInPacket implements InPacket {
 		var requiredExclusions = buf.readInt();
 
 		return new ClientSkillDefinitionConfig(
-				id,
-				title,
-				description,
-				extraDescription,
-				icon,
-				frame,
-				size,
-				cost,
+			id,
+			type,
+			maxLevels,
+			descriptions,
+			extraDescriptions,
+			title,
+			icon,
+			frame,
+			size,
+			cost,
 				requiredSkills,
 				requiredPoints,
 				requiredSpentPoints,

--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
@@ -1,6 +1,7 @@
 package net.puffish.skillsmod.config.skill;
 
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import net.puffish.skillsmod.api.config.ConfigContext;
 import net.puffish.skillsmod.api.json.BuiltinJson;
 import net.puffish.skillsmod.api.json.JsonElement;
@@ -17,9 +18,11 @@ import java.util.List;
 
 public record SkillDefinitionConfig(
 		String id,
+		Identifier type,
+		int maxLevels,
+		List<Text> descriptions,
+		List<Text> extraDescriptions,
 		Text title,
-		Text description,
-		Text extraDescription,
 		IconConfig icon,
 		FrameConfig frame,
 		float size,
@@ -45,21 +48,47 @@ public record SkillDefinitionConfig(
 				.ifFailure(problems::add)
 				.getSuccess();
 
-		var description = rootObject.get("description")
+		var type = rootObject.get("type")
 				.getSuccess() // ignore failure because this property is optional
-				.flatMap(descriptionElement -> BuiltinJson.parseText(descriptionElement)
+				.flatMap(element -> BuiltinJson.parseIdentifier(element)
 						.ifFailure(problems::add)
-						.getSuccess()
-				)
-				.orElseGet(Text::empty);
+						.getSuccess())
+				.orElse(Identifier.of("puffish_skills", "default"));
 
-		var extraDescription = rootObject.get("extra_description")
+		var maxLevels = rootObject.get("max_levels")
 				.getSuccess() // ignore failure because this property is optional
-				.flatMap(descriptionElement -> BuiltinJson.parseText(descriptionElement)
+				.flatMap(element -> element.getAsInt()
 						.ifFailure(problems::add)
-						.getSuccess()
-				)
-				.orElseGet(Text::empty);
+						.getSuccess())
+				.orElse(1);
+
+		var descriptions = rootObject.getArray("descriptions")
+				.getSuccess() // ignore failure because this property is optional
+				.flatMap(array -> array.getAsList((i, e) -> BuiltinJson.parseText(e))
+						.mapFailure(Problem::combine)
+						.ifFailure(problems::add)
+						.getSuccess())
+				.orElseGet(() -> rootObject.get("description")
+						.getSuccess() // ignore failure because this property is optional
+						.flatMap(element -> BuiltinJson.parseText(element)
+								.ifFailure(problems::add)
+								.getSuccess())
+						.map(List::of)
+						.orElseGet(List::of));
+
+		var extraDescriptions = rootObject.getArray("extra_descriptions")
+				.getSuccess() // ignore failure because this property is optional
+				.flatMap(array -> array.getAsList((i, e) -> BuiltinJson.parseText(e))
+						.mapFailure(Problem::combine)
+						.ifFailure(problems::add)
+						.getSuccess())
+				.orElseGet(() -> rootObject.get("extra_description")
+						.getSuccess() // ignore failure because this property is optional
+						.flatMap(element -> BuiltinJson.parseText(element)
+								.ifFailure(problems::add)
+								.getSuccess())
+						.map(List::of)
+						.orElseGet(List::of));
 
 		var optIcon = rootObject.get("icon")
 				.andThen(element -> IconConfig.parse(element, context))
@@ -135,9 +164,11 @@ public record SkillDefinitionConfig(
 		if (problems.isEmpty()) {
 			return Result.success(new SkillDefinitionConfig(
 					id,
+					type,
+					maxLevels,
+					descriptions,
+					extraDescriptions,
 					optTitle.orElseThrow(),
-					description,
-					extraDescription,
 					optIcon.orElseThrow(),
 					frame,
 					size,

--- a/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ShowCategoryOutPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ShowCategoryOutPacket.java
@@ -72,9 +72,11 @@ public record ShowCategoryOutPacket(CategoryConfig category, CategoryData catego
 
 	public void write(PacketByteBuf buf, SkillDefinitionConfig definition) {
 		buf.writeString(definition.id());
+		buf.writeIdentifier(definition.type());
+		buf.writeInt(definition.maxLevels());
+		buf.writeCollection(definition.descriptions(), PacketByteBuf::writeText);
+		buf.writeCollection(definition.extraDescriptions(), PacketByteBuf::writeText);
 		buf.writeText(definition.title());
-		buf.writeText(definition.description());
-		buf.writeText(definition.extraDescription());
 		write(buf, definition.frame());
 		write(buf, definition.icon());
 		buf.writeFloat(definition.size());


### PR DESCRIPTION
## Summary
- allow multiple skill descriptions and extra descriptions
- support custom skill definition types and max levels
- send new fields in ShowCategory packets
- update client models and UI to show new descriptions
- fix indentation for new code

## Testing
- `./gradlew checkstyleMain`

------
https://chatgpt.com/codex/tasks/task_e_68844fa8de908327acda408f85b491d8