### PR TITLE
Add README with MyStackableSkills note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Pufferfish's Skill Leveling
+
+This repository contains the source of the Pufferfish's Skills mod.
+
+## Stackable Skills
+
+This mod can integrate with additional skill types provided by other mods. The example data pack (`example-skill-level-template.zip`) demonstrates a stackable skill defined with the ID `mystackableskills:stackable`.
+
+The `mystackableskills:stackable` type is provided by the **MyStackableSkills** mod ([GitHub](https://github.com/DeveloperNoShinigami/MyStackableSkills)). You must install that mod, or another implementation providing this identifier, for stackable skills using this type to function.
+


### PR DESCRIPTION
## Summary
- add a small README.md
- document that the `mystackableskills:stackable` type comes from the MyStackableSkills mod and requires that dependency

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6888bfb783d88327bda0f45d2a0aa04d