### PR TITLE
Fix reward disposal

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
@@ -14,6 +14,7 @@ import net.puffish.skillsmod.api.util.Problem;
 import net.puffish.skillsmod.api.util.Result;
 import net.puffish.skillsmod.config.skill.SkillRewardConfig;
 import net.puffish.skillsmod.impl.rewards.RewardUpdateContextImpl;
+import net.puffish.skillsmod.util.DisposeContext;
 import net.puffish.skillsmod.util.LegacyUtils;
 
 import java.util.ArrayList;
@@ -90,9 +91,10 @@ public class PerLevelRewardsReward implements Reward {
 
     @Override
     public void dispose(RewardDisposeContext context) {
+        var disposeContext = new DisposeContext(context.getServer());
         for (var rewardList : levelRewards.values()) {
             for (var reward : rewardList) {
-                reward.dispose(context);
+                reward.dispose(disposeContext);
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure `PerLevelRewardsReward` passes a `DisposeContext` to nested rewards

## Testing
- `./gradlew :Common:compileJava`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68894333067c83278e5a1b16d22f67b0