### PR TITLE
Fix texture registration concurrency crash

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/client/config/ClientBackgroundConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/config/ClientBackgroundConfig.java
@@ -29,11 +29,13 @@ public record ClientBackgroundConfig(
 			int height,
 			BackgroundPosition position
 	) {
-		var id = SkillsMod.createIdentifier(RandomStringUtils.random(16, "abcdefghijklmnopqrstuvwxyz0123456789"));
-		var texture = new ClientBackgroundTexture(textureId);
-		MinecraftClient.getInstance()
-				.getTextureManager()
-				.registerTexture(id, texture);
+                var id = SkillsMod.createIdentifier(RandomStringUtils.random(16, "abcdefghijklmnopqrstuvwxyz0123456789"));
+                var texture = new ClientBackgroundTexture(textureId);
+                MinecraftClient.getInstance().submit(() ->
+                        MinecraftClient.getInstance()
+                                        .getTextureManager()
+                                        .registerTexture(id, texture)
+                );
 
 		return new ClientBackgroundConfig(
 				id,


### PR DESCRIPTION
## Summary
- register textures on the client thread using `MinecraftClient.submit` to avoid concurrent modification of the texture manager

## Testing
- `./gradlew check` *(fails: Checkstyle rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_688999a67d108327b48c7d4b3da9b706