### PR TITLE
Fix stacked skill rewards and selection

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -693,15 +693,17 @@ public class SkillsMod {
 		}
 	}
 
-	private void updateSkillRewards(ServerPlayerEntity player, CategoryConfig category, CategoryData categoryData, SkillConfig skill, boolean isUnlock) {
-		category.definitions().getById(skill.definitionId()).ifPresent(definition -> {
-			var count = categoryData.countUnlocked(category, definition.id());
+        private void updateSkillRewards(ServerPlayerEntity player, CategoryConfig category, CategoryData categoryData, SkillConfig skill, boolean isUnlock) {
+                category.definitions().getById(skill.definitionId()).ifPresent(definition -> {
+                        var count = categoryData.countUnlocked(category, definition.id());
 
-			for (var reward : definition.rewards()) {
-				reward.instance().update(new RewardUpdateContextImpl(player, count, isUnlock));
-			}
-		});
-	}
+                        var action = isUnlock && count == 1;
+
+                        for (var reward : definition.rewards()) {
+                                reward.instance().update(new RewardUpdateContextImpl(player, count, action));
+                        }
+                });
+        }
 
 	private void resetRewards(ServerPlayerEntity player, CategoryConfig category) {
 		for (var definition : category.definitions().getAll()) {

--- a/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
@@ -290,17 +290,20 @@ public class SkillsScreen extends Screen {
 		var activeCategory = activeCategoryData.getConfig();
 
                 if (isInsideContent(mouse)) {
-                        activeCategory.skills().values().stream()
+                        var stream = activeCategory.skills().values().stream()
                                         .filter(skill -> activeCategory
                                                         .getDefinitionById(skill.definitionId())
                                                         .map(definition -> isInsideSkill(transformedMouse, skill, definition))
-                                                        .orElse(false))
+                                                        .orElse(false));
+
+                        stream.filter(skill -> activeCategoryData.getSkillState(skill) != Skill.State.UNLOCKED)
                                         .findFirst()
+                                        .or(() -> stream.findFirst())
                                         .ifPresent(skill -> SkillsClientMod.getInstance()
                                                         .getPacketSender()
                                                         .send(new SkillClickOutPacket(activeCategory.id(), skill.id())));
                 }
-	}
+        }
 
 	@Override
 	public boolean keyPressed(int keyCode, int scanCode, int modifiers) {


### PR DESCRIPTION
## Summary
- ensure only the first unlock triggers skill action rewards
- prefer unspent stacked skills when clicking overlapping nodes

## Testing
- `./gradlew test` *(fails: could not complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6889a85e04608327901fcdeb2d889c7b