### PR TITLE
Implement optional fields in PerLevelRewardsReward

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -35,7 +35,7 @@ import net.puffish.skillsmod.config.skill.SkillConfig;
 import net.puffish.skillsmod.config.skill.SkillRewardConfig;
 import net.puffish.skillsmod.experience.source.BuiltinExperienceSources;
 import net.puffish.skillsmod.impl.config.ConfigContextImpl;
-import net.puffish.skillsmod.impl.rewards.RewardUpdateContextImpl;
+import net.puffish.skillsmod.impl.rewards.SkillRewardUpdateContextImpl;
 import net.puffish.skillsmod.network.Packets;
 import net.puffish.skillsmod.reward.BuiltinRewards;
 import net.puffish.skillsmod.reward.builtin.PointsReward;
@@ -673,25 +673,39 @@ public class SkillsMod {
 				for (var definition : category.definitions().getAll()) {
 					var count = categoryData.countUnlocked(category, definition.id());
 
-					for (var reward : definition.rewards()) {
-						if (predicate.test(reward)) {
-							reward.instance().update(new RewardUpdateContextImpl(player, count, false));
-						}
-					}
+                                        for (var reward : definition.rewards()) {
+                                                if (predicate.test(reward)) {
+                                                        reward.instance().update(
+                                                                new SkillRewardUpdateContextImpl(
+                                                                        player,
+                                                                        count,
+                                                                        false,
+                                                                        category.id(),
+                                                                        null
+                                                                )
+                                                        );
+                                                }
+                                        }
 				}
 			});
 		}
 	}
 
-	private void updateRewards(ServerPlayerEntity player, CategoryConfig category, CategoryData categoryData) {
-		for (var definition : category.definitions().getAll()) {
-			var count = categoryData.countUnlocked(category, definition.id());
+        private void updateRewards(ServerPlayerEntity player, CategoryConfig category, CategoryData categoryData) {
+                for (var definition : category.definitions().getAll()) {
+                        var count = categoryData.countUnlocked(category, definition.id());
 
-			for (var reward : definition.rewards()) {
-				reward.instance().update(new RewardUpdateContextImpl(player, count, false));
-			}
-		}
-	}
+                        for (var reward : definition.rewards()) {
+                                reward.instance().update(new SkillRewardUpdateContextImpl(
+                                                player,
+                                                count,
+                                                false,
+                                                category.id(),
+                                                null
+                                ));
+                        }
+                }
+        }
 
         private void updateSkillRewards(ServerPlayerEntity player, CategoryConfig category, CategoryData categoryData, SkillConfig skill, boolean isUnlock) {
                 category.definitions().getById(skill.definitionId()).ifPresent(definition -> {
@@ -700,18 +714,30 @@ public class SkillsMod {
                         var action = isUnlock && count == 1;
 
                         for (var reward : definition.rewards()) {
-                                reward.instance().update(new RewardUpdateContextImpl(player, count, action));
+                                reward.instance().update(new SkillRewardUpdateContextImpl(
+                                                player,
+                                                count,
+                                                action,
+                                                category.id(),
+                                                skill.id()
+                                ));
                         }
                 });
         }
 
-	private void resetRewards(ServerPlayerEntity player, CategoryConfig category) {
-		for (var definition : category.definitions().getAll()) {
-			for (var reward : definition.rewards()) {
-				reward.instance().update(new RewardUpdateContextImpl(player, 0, false));
-			}
-		}
-	}
+        private void resetRewards(ServerPlayerEntity player, CategoryConfig category) {
+                for (var definition : category.definitions().getAll()) {
+                        for (var reward : definition.rewards()) {
+                                reward.instance().update(new SkillRewardUpdateContextImpl(
+                                                player,
+                                                0,
+                                                false,
+                                                category.id(),
+                                                null
+                                ));
+                        }
+                }
+        }
 
 	private Optional<CategoryData> getCategoryDataIfUnlocked(ServerPlayerEntity player, CategoryConfig category) {
 		return getCategoryDataIfUnlocked(getPlayerData(player), category);

--- a/Common/src/main/java/net/puffish/skillsmod/impl/rewards/SkillRewardUpdateContext.java
+++ b/Common/src/main/java/net/puffish/skillsmod/impl/rewards/SkillRewardUpdateContext.java
@@ -1,0 +1,9 @@
+package net.puffish.skillsmod.impl.rewards;
+
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.api.reward.RewardUpdateContext;
+
+public interface SkillRewardUpdateContext extends RewardUpdateContext {
+    Identifier getCategoryId();
+    String getSkillId();
+}

--- a/Common/src/main/java/net/puffish/skillsmod/impl/rewards/SkillRewardUpdateContextImpl.java
+++ b/Common/src/main/java/net/puffish/skillsmod/impl/rewards/SkillRewardUpdateContextImpl.java
@@ -1,0 +1,37 @@
+package net.puffish.skillsmod.impl.rewards;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+public record SkillRewardUpdateContextImpl(
+        ServerPlayerEntity player,
+        int count,
+        boolean isAction,
+        Identifier categoryId,
+        String skillId
+) implements SkillRewardUpdateContext {
+    @Override
+    public ServerPlayerEntity getPlayer() {
+        return player;
+    }
+
+    @Override
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean isAction() {
+        return isAction;
+    }
+
+    @Override
+    public Identifier getCategoryId() {
+        return categoryId;
+    }
+
+    @Override
+    public String getSkillId() {
+        return skillId;
+    }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
@@ -13,7 +13,9 @@ import net.puffish.skillsmod.api.reward.RewardUpdateContext;
 import net.puffish.skillsmod.api.util.Problem;
 import net.puffish.skillsmod.api.util.Result;
 import net.puffish.skillsmod.config.skill.SkillRewardConfig;
-import net.puffish.skillsmod.impl.rewards.RewardUpdateContextImpl;
+import net.puffish.skillsmod.impl.rewards.SkillRewardUpdateContext;
+import net.puffish.skillsmod.impl.rewards.SkillRewardUpdateContextImpl;
+import org.apache.commons.lang3.RandomStringUtils;
 import net.puffish.skillsmod.util.DisposeContext;
 import net.puffish.skillsmod.util.LegacyUtils;
 
@@ -23,18 +25,21 @@ import java.util.List;
 import java.util.Map;
 
 public class PerLevelRewardsReward implements Reward {
-	public static final Identifier ID = SkillsMod.createIdentifier("per_level_rewards");
+        public static final Identifier ID = SkillsMod.createIdentifier("per_level_rewards");
+    private static final String PREFIX = "per_level_rewards.";
 
     private final Map<Integer, List<SkillRewardConfig>> levelRewards;
     private final String skillId;
     private final int maxLevel;
     private final int pointsPerLevel;
+    private final Identifier source;
 
-    private PerLevelRewardsReward(Map<Integer, List<SkillRewardConfig>> levelRewards, String skillId, int maxLevel, int pointsPerLevel) {
+    private PerLevelRewardsReward(Map<Integer, List<SkillRewardConfig>> levelRewards, String skillId, int maxLevel, int pointsPerLevel, Identifier source) {
         this.levelRewards = levelRewards;
         this.skillId = skillId;
         this.maxLevel = maxLevel;
         this.pointsPerLevel = pointsPerLevel;
+        this.source = source;
     }
 
 	public static void register() {
@@ -89,7 +94,8 @@ public class PerLevelRewardsReward implements Reward {
                                 levelRewards,
                                 optSkillId.orElse(null),
                                 optMaxLevel.orElse(Integer.MAX_VALUE),
-                                optPointsPerLevel.orElse(0)
+                                optPointsPerLevel.orElse(0),
+                                SkillsMod.createIdentifier(PREFIX + org.apache.commons.lang3.RandomStringUtils.random(16, "abcdefghijklmnopqrstuvwxyz0123456789"))
                 ));
         } else {
                 return Result.failure(Problem.combine(problems));
@@ -98,27 +104,59 @@ public class PerLevelRewardsReward implements Reward {
 
         @Override
         public void update(RewardUpdateContext context) {
-        int currentLevel = Math.min(context.getCount(), maxLevel);
-        for (var entry : levelRewards.entrySet()) {
-                int level = entry.getKey();
-                int count = currentLevel >= level ? 1 : 0;
-                for (var reward : entry.getValue()) {
-                        reward.instance().update(new RewardUpdateContextImpl(context.getPlayer(), count, context.isAction()));
+                if (skillId != null) {
+                        if (!(context instanceof SkillRewardUpdateContext sruc) || !skillId.equals(sruc.getSkillId())) {
+                                return;
+                        }
+                }
+
+                int currentLevel = Math.min(context.getCount(), maxLevel);
+
+                Identifier categoryId = null;
+                String currentSkillId = null;
+                if (context instanceof SkillRewardUpdateContext sruc) {
+                        categoryId = sruc.getCategoryId();
+                        currentSkillId = sruc.getSkillId();
+                }
+
+                for (var entry : levelRewards.entrySet()) {
+                        int level = entry.getKey();
+                        int count = currentLevel >= level ? 1 : 0;
+                        for (var reward : entry.getValue()) {
+                                reward.instance().update(new SkillRewardUpdateContextImpl(
+                                                context.getPlayer(),
+                                                count,
+                                                context.isAction(),
+                                                categoryId,
+                                                currentSkillId
+                                ));
+                        }
+                }
+
+                if (pointsPerLevel != 0 && categoryId != null) {
+                        SkillsMod.getInstance().setPoints(
+                                        context.getPlayer(),
+                                        categoryId,
+                                        source,
+                                        pointsPerLevel * currentLevel,
+                                        !context.isAction()
+                        );
                 }
         }
 
-        if (pointsPerLevel != 0 && context.isAction()) {
-                context.getPlayer().addExperience(pointsPerLevel * currentLevel);
-        }
+        @Override
+        public void dispose(RewardDisposeContext context) {
+        var disposeContext = new DisposeContext(context.getServer());
+        for (var rewardList : levelRewards.values()) {
+                for (var reward : rewardList) {
+                        reward.dispose(disposeContext);
+                }
         }
 
-	@Override
-	public void dispose(RewardDisposeContext context) {
-	var disposeContext = new DisposeContext(context.getServer());
-	for (var rewardList : levelRewards.values()) {
-		for (var reward : rewardList) {
-		reward.dispose(disposeContext);
-		}
-	}
-	}
+        context.getServer().getPlayerManager().getPlayerList().forEach(player -> {
+                SkillsAPI.streamCategories().forEach(category -> {
+                        category.setPoints(player, source, 0);
+                });
+        });
+        }
 }

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
@@ -25,11 +25,17 @@ import java.util.Map;
 public class PerLevelRewardsReward implements Reward {
 	public static final Identifier ID = SkillsMod.createIdentifier("per_level_rewards");
 
-	private final Map<Integer, List<SkillRewardConfig>> levelRewards;
+    private final Map<Integer, List<SkillRewardConfig>> levelRewards;
+    private final String skillId;
+    private final int maxLevel;
+    private final int pointsPerLevel;
 
-	private PerLevelRewardsReward(Map<Integer, List<SkillRewardConfig>> levelRewards) {
-	this.levelRewards = levelRewards;
-	}
+    private PerLevelRewardsReward(Map<Integer, List<SkillRewardConfig>> levelRewards, String skillId, int maxLevel, int pointsPerLevel) {
+        this.levelRewards = levelRewards;
+        this.skillId = skillId;
+        this.maxLevel = maxLevel;
+        this.pointsPerLevel = pointsPerLevel;
+    }
 
 	public static void register() {
 	SkillsAPI.registerReward(ID, PerLevelRewardsReward::parse);
@@ -66,28 +72,45 @@ public class PerLevelRewardsReward implements Reward {
 		}
 	});
 
-	// Access optional fields to avoid unused warnings
-	rootObject.get("skill_id");
-	rootObject.get("max_level");
-	rootObject.get("points_per_level");
+        var optSkillId = rootObject.getString("skill_id")
+                .ifFailure(problems::add)
+                .getSuccess();
 
-	if (problems.isEmpty()) {
-		return Result.success(new PerLevelRewardsReward(levelRewards));
-	} else {
-		return Result.failure(Problem.combine(problems));
-	}
+        var optMaxLevel = rootObject.getInt("max_level")
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        var optPointsPerLevel = rootObject.getInt("points_per_level")
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        if (problems.isEmpty()) {
+                return Result.success(new PerLevelRewardsReward(
+                                levelRewards,
+                                optSkillId.orElse(null),
+                                optMaxLevel.orElse(Integer.MAX_VALUE),
+                                optPointsPerLevel.orElse(0)
+                ));
+        } else {
+                return Result.failure(Problem.combine(problems));
+        }
 	}
 
-	@Override
-	public void update(RewardUpdateContext context) {
-	for (var entry : levelRewards.entrySet()) {
-		int level = entry.getKey();
-		int count = context.getCount() >= level ? 1 : 0;
-		for (var reward : entry.getValue()) {
-		reward.instance().update(new RewardUpdateContextImpl(context.getPlayer(), count, context.isAction()));
-		}
-	}
-	}
+        @Override
+        public void update(RewardUpdateContext context) {
+        int currentLevel = Math.min(context.getCount(), maxLevel);
+        for (var entry : levelRewards.entrySet()) {
+                int level = entry.getKey();
+                int count = currentLevel >= level ? 1 : 0;
+                for (var reward : entry.getValue()) {
+                        reward.instance().update(new RewardUpdateContextImpl(context.getPlayer(), count, context.isAction()));
+                }
+        }
+
+        if (pointsPerLevel != 0 && context.isAction()) {
+                context.getPlayer().addExperience(pointsPerLevel * currentLevel);
+        }
+        }
 
 	@Override
 	public void dispose(RewardDisposeContext context) {

--- a/Common/src/test/java/net/puffish/skillsmod/reward/PerLevelRewardsRewardTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/reward/PerLevelRewardsRewardTest.java
@@ -1,0 +1,41 @@
+package net.puffish.skillsmod.reward;
+
+import net.minecraft.server.MinecraftServer;
+import net.puffish.skillsmod.api.config.ConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonPath;
+import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PerLevelRewardsRewardTest {
+    private static class DummyContext implements ConfigContext {
+        @Override
+        public MinecraftServer getServer() {
+            return null;
+        }
+
+        @Override
+        public void emitWarning(String message) {
+            // ignore
+        }
+    }
+
+    @Test
+    public void testParseOptionalFields() {
+        String json = """
+                {
+                  \"levels\": {},
+                  \"skill_id\": \"test_skill\",
+                  \"max_level\": 2,
+                  \"points_per_level\": 3
+                }
+                """;
+        var element = JsonElement.parseString(json, JsonPath.create("test"))
+                .getSuccess().orElseThrow();
+
+        var result = PerLevelRewardsReward.parse(element.getAsObject().getSuccess().orElseThrow(), new DummyContext());
+        Assertions.assertTrue(result.getSuccess().isPresent(),
+                result.getFailure().map(Object::toString).orElse("Unexpected failure"));
+    }
+}


### PR DESCRIPTION
## Summary
- parse and store new optional fields in `PerLevelRewardsReward`
- cap applied rewards with `max_level`
- grant experience based on `points_per_level`
- add a simple unit test covering optional field parsing

## Testing
- `./gradlew test` *(fails: patched jars - access transforming minecraft)*

------
https://chatgpt.com/codex/tasks/task_e_688a2f37fd348327b2e940e8568fc022