### PR TITLE
Add parent description merging

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
@@ -18,8 +18,9 @@ import java.util.List;
 
 public record SkillDefinitionConfig(
 
-		String id,
-		Identifier type,
+                String id,
+                java.util.Optional<String> parent,
+                Identifier type,
 		int maxLevels,
 		List<Text> descriptions,
 		List<Text> extraDescriptions,
@@ -47,10 +48,18 @@ public record SkillDefinitionConfig(
 		var problems = new ArrayList<Problem>();
 
 
-		var optTitle = rootObject.get("title")
-				.andThen(BuiltinJson::parseText)
-				.ifFailure(problems::add)
-				.getSuccess();
+                var optTitle = rootObject.get("title")
+                                .andThen(BuiltinJson::parseText)
+                                .ifFailure(problems::add)
+                                .getSuccess();
+
+                var optParent = rootObject.get("parent")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(element -> element.getAsString()
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElse(null);
 
 		var type = rootObject.get("type")
 				.getSuccess() // ignore failure because this property is optional
@@ -176,10 +185,11 @@ public record SkillDefinitionConfig(
 
 
 		if (problems.isEmpty()) {
-			return Result.success(new SkillDefinitionConfig(
-					id,
-					type,
-					maxLevels,
+                        return Result.success(new SkillDefinitionConfig(
+                                        id,
+                                        java.util.Optional.ofNullable(optParent),
+                                        type,
+                                        maxLevels,
 					descriptions,
 					extraDescriptions,
 					optTitle.orElseThrow(),

--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionsConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionsConfig.java
@@ -22,11 +22,77 @@ public class SkillDefinitionsConfig {
 		return rootElement.getAsObject().andThen(rootObject -> parse(rootObject, context));
 	}
 
-	public static Result<SkillDefinitionsConfig, Problem> parse(JsonObject rootObject, ConfigContext context) {
-		return rootObject.getAsMap((id, element) -> SkillDefinitionConfig.parse(id, element, context))
-				.mapFailure(problems -> Problem.combine(problems.values()))
-				.mapSuccess(SkillDefinitionsConfig::new);
-	}
+        public static Result<SkillDefinitionsConfig, Problem> parse(JsonObject rootObject, ConfigContext context) {
+                return rootObject.getAsMap((id, element) -> SkillDefinitionConfig.parse(id, element, context))
+                                .mapFailure(problems -> Problem.combine(problems.values()))
+                                .andThen(map -> {
+                                        var problems = new java.util.ArrayList<Problem>();
+                                        var merged = new java.util.HashMap<String, SkillDefinitionConfig>();
+                                        for (var entry : map.entrySet()) {
+                                                merge(entry.getKey(), map, merged, new java.util.HashSet<>(), problems);
+                                        }
+                                        if (problems.isEmpty()) {
+                                                return Result.success(new SkillDefinitionsConfig(merged));
+                                        } else {
+                                                return Result.failure(Problem.combine(problems));
+                                        }
+                                });
+        }
+
+        private static SkillDefinitionConfig merge(String id, Map<String, SkillDefinitionConfig> all,
+                                    Map<String, SkillDefinitionConfig> merged,
+                                    java.util.Set<String> visiting,
+                                    java.util.List<Problem> problems) {
+                if (merged.containsKey(id)) {
+                        return merged.get(id);
+                }
+                if (!visiting.add(id)) {
+                        problems.add(Problem.of("Cycle in skill definition inheritance at '" + id + "'"));
+                        return null;
+                }
+                var def = all.get(id);
+                if (def == null) {
+                        problems.add(Problem.of("Unknown skill definition '" + id + "'"));
+                        return null;
+                }
+                java.util.List<net.minecraft.text.Text> descriptions = def.descriptions();
+                java.util.List<net.minecraft.text.Text> extra = def.extraDescriptions();
+                if (def.mergeDescription() && def.parent().isPresent()) {
+                        var parentId = def.parent().get();
+                        var parentObj = merge(parentId, all, merged, visiting, problems);
+                        if (parentObj != null) {
+                                descriptions = new java.util.ArrayList<>(parentObj.descriptions());
+                                descriptions.addAll(def.descriptions());
+                                extra = new java.util.ArrayList<>(parentObj.extraDescriptions());
+                                extra.addAll(def.extraDescriptions());
+                        }
+                } else if (def.parent().isPresent()) {
+                        merge(def.parent().get(), all, merged, visiting, problems);
+                }
+                visiting.remove(id);
+
+                var mergedDef = new SkillDefinitionConfig(
+                                def.id(),
+                                def.parent(),
+                                def.type(),
+                                def.maxLevels(),
+                                descriptions,
+                                extra,
+                                def.title(),
+                                def.icon(),
+                                def.frame(),
+                                def.size(),
+                                def.mergeDescription(),
+                                def.rewards(),
+                                def.cost(),
+                                def.requiredSkills(),
+                                def.requiredPoints(),
+                                def.requiredSpentPoints(),
+                                def.requiredExclusions()
+                );
+                merged.put(id, mergedDef);
+                return mergedDef;
+        }
 
 	public Optional<SkillDefinitionConfig> getById(String id) {
 		return Optional.ofNullable(definitions.get(id));

--- a/Common/src/test/java/net/puffish/skillsmod/config/SkillDefinitionConfigTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/config/SkillDefinitionConfigTest.java
@@ -5,6 +5,7 @@ import net.puffish.skillsmod.api.config.ConfigContext;
 import net.puffish.skillsmod.api.json.JsonElement;
 import net.puffish.skillsmod.api.json.JsonPath;
 import net.puffish.skillsmod.config.skill.SkillDefinitionConfig;
+import net.puffish.skillsmod.config.skill.SkillDefinitionsConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -40,5 +41,40 @@ public class SkillDefinitionConfigTest {
                 result.getFailure().map(Object::toString).orElse("Unexpected failure"));
         var config = result.getSuccess().orElseThrow();
         Assertions.assertTrue(config.mergeDescription());
+    }
+
+    @Test
+    public void testParentDescriptionMerge() {
+        String json = """
+                {
+                  \"parent\": {
+                    \"title\": {\"text\": \"Parent\"},
+                    \"icon\": {\"type\": \"texture\", \"data\": {\"texture\": \"minecraft:stone\"}},
+                    \"descriptions\": [\"A\"],
+                    \"extra_descriptions\": [\"EA\"]
+                  },
+                  \"child\": {
+                    \"title\": {\"text\": \"Child\"},
+                    \"icon\": {\"type\": \"texture\", \"data\": {\"texture\": \"minecraft:stone\"}},
+                    \"parent\": \"parent\",
+                    \"merge_description\": true,
+                    \"descriptions\": [\"B\"],
+                    \"extra_descriptions\": [\"EB\"]
+                  }
+                }
+                """;
+
+        var element = JsonElement.parseString(json, JsonPath.create("test"))
+                .getSuccess().orElseThrow();
+
+        var result = SkillDefinitionsConfig.parse(element, new DummyContext());
+        Assertions.assertTrue(result.getSuccess().isPresent(),
+                result.getFailure().map(Object::toString).orElse("Unexpected failure"));
+        var defs = result.getSuccess().orElseThrow();
+        var child = defs.getById("child").orElseThrow();
+        Assertions.assertEquals(2, child.descriptions().size());
+        Assertions.assertEquals(2, child.extraDescriptions().size());
+        Assertions.assertEquals("A", child.descriptions().get(0).getString());
+        Assertions.assertEquals("EA", child.extraDescriptions().get(0).getString());
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Skill definitions describe how a skill looks and what it grants. Datapacks may n
 - `max_levels` – how many times the skill can be unlocked.
 - `descriptions` – list of tooltip lines shown for each level.
 - `extra_descriptions` – list of extra tooltip lines (displayed while holding Shift).
-- `merge_description` – merges descriptions with inherited definitions. Defaults to `false` when omitted. You only want to use this when you are adding the total number of rewards together (such as origins skill types, effect, or command even), other wise you will want to write what the progression of the reward would look like.
+- `parent` – id of another definition to inherit from.
+- `merge_description` – when `true`, descriptions and extra descriptions from the parent are appended to this definition's own lists. Defaults to `false` when omitted. You only want to use this when you are adding the total number of rewards together (such as origins skill types, effect, or command even), other wise you will want to write what the progression of the reward would look like.
 
 - Tooltip lines automatically adjust based on how many times the skill has been unlocked. When hovering a skill, the
   entry matching the player's current level is shown, and holding Shift displays the line for the next level (or a final


### PR DESCRIPTION
## Summary
- add `parent` field to skill definition config
- merge descriptions from parent definitions when `merge_description` is true
- document the new `parent` property
- cover description inheritance in tests

## Testing
- `./gradlew test` *(fails: Execution failed for task ':Common:compileJava')*

------
https://chatgpt.com/codex/tasks/task_e_688a2f38a8b483279e10ded52c88f42b