### PR TITLE
Remove parent inheritance from skill definitions

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
@@ -19,7 +19,6 @@ import java.util.List;
 public record SkillDefinitionConfig(
 
                 String id,
-                java.util.Optional<String> parent,
                 Identifier type,
 		int maxLevels,
 		List<Text> descriptions,
@@ -53,13 +52,6 @@ public record SkillDefinitionConfig(
                                 .ifFailure(problems::add)
                                 .getSuccess();
 
-                var optParent = rootObject.get("parent")
-                                .getSuccess() // ignore failure because this property is optional
-                                .flatMap(element -> element.getAsString()
-                                                .ifFailure(problems::add)
-                                                .getSuccess()
-                                )
-                                .orElse(null);
 
 		var type = rootObject.get("type")
 				.getSuccess() // ignore failure because this property is optional
@@ -187,7 +179,6 @@ public record SkillDefinitionConfig(
 		if (problems.isEmpty()) {
                         return Result.success(new SkillDefinitionConfig(
                                         id,
-                                        java.util.Optional.ofNullable(optParent),
                                         type,
                                         maxLevels,
 					descriptions,

--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionsConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionsConfig.java
@@ -25,73 +25,7 @@ public class SkillDefinitionsConfig {
         public static Result<SkillDefinitionsConfig, Problem> parse(JsonObject rootObject, ConfigContext context) {
                 return rootObject.getAsMap((id, element) -> SkillDefinitionConfig.parse(id, element, context))
                                 .mapFailure(problems -> Problem.combine(problems.values()))
-                                .andThen(map -> {
-                                        var problems = new java.util.ArrayList<Problem>();
-                                        var merged = new java.util.HashMap<String, SkillDefinitionConfig>();
-                                        for (var entry : map.entrySet()) {
-                                                merge(entry.getKey(), map, merged, new java.util.HashSet<>(), problems);
-                                        }
-                                        if (problems.isEmpty()) {
-                                                return Result.success(new SkillDefinitionsConfig(merged));
-                                        } else {
-                                                return Result.failure(Problem.combine(problems));
-                                        }
-                                });
-        }
-
-        private static SkillDefinitionConfig merge(String id, Map<String, SkillDefinitionConfig> all,
-                                    Map<String, SkillDefinitionConfig> merged,
-                                    java.util.Set<String> visiting,
-                                    java.util.List<Problem> problems) {
-                if (merged.containsKey(id)) {
-                        return merged.get(id);
-                }
-                if (!visiting.add(id)) {
-                        problems.add(Problem.of("Cycle in skill definition inheritance at '" + id + "'"));
-                        return null;
-                }
-                var def = all.get(id);
-                if (def == null) {
-                        problems.add(Problem.of("Unknown skill definition '" + id + "'"));
-                        return null;
-                }
-                java.util.List<net.minecraft.text.Text> descriptions = def.descriptions();
-                java.util.List<net.minecraft.text.Text> extra = def.extraDescriptions();
-                if (def.mergeDescription() && def.parent().isPresent()) {
-                        var parentId = def.parent().get();
-                        var parentObj = merge(parentId, all, merged, visiting, problems);
-                        if (parentObj != null) {
-                                descriptions = new java.util.ArrayList<>(parentObj.descriptions());
-                                descriptions.addAll(def.descriptions());
-                                extra = new java.util.ArrayList<>(parentObj.extraDescriptions());
-                                extra.addAll(def.extraDescriptions());
-                        }
-                } else if (def.parent().isPresent()) {
-                        merge(def.parent().get(), all, merged, visiting, problems);
-                }
-                visiting.remove(id);
-
-                var mergedDef = new SkillDefinitionConfig(
-                                def.id(),
-                                def.parent(),
-                                def.type(),
-                                def.maxLevels(),
-                                descriptions,
-                                extra,
-                                def.title(),
-                                def.icon(),
-                                def.frame(),
-                                def.size(),
-                                def.mergeDescription(),
-                                def.rewards(),
-                                def.cost(),
-                                def.requiredSkills(),
-                                def.requiredPoints(),
-                                def.requiredSpentPoints(),
-                                def.requiredExclusions()
-                );
-                merged.put(id, mergedDef);
-                return mergedDef;
+                                .mapSuccess(SkillDefinitionsConfig::new);
         }
 
 	public Optional<SkillDefinitionConfig> getById(String id) {

--- a/Common/src/test/java/net/puffish/skillsmod/config/SkillDefinitionConfigTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/config/SkillDefinitionConfigTest.java
@@ -5,7 +5,6 @@ import net.puffish.skillsmod.api.config.ConfigContext;
 import net.puffish.skillsmod.api.json.JsonElement;
 import net.puffish.skillsmod.api.json.JsonPath;
 import net.puffish.skillsmod.config.skill.SkillDefinitionConfig;
-import net.puffish.skillsmod.config.skill.SkillDefinitionsConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,38 +42,4 @@ public class SkillDefinitionConfigTest {
         Assertions.assertTrue(config.mergeDescription());
     }
 
-    @Test
-    public void testParentDescriptionMerge() {
-        String json = """
-                {
-                  \"parent\": {
-                    \"title\": {\"text\": \"Parent\"},
-                    \"icon\": {\"type\": \"texture\", \"data\": {\"texture\": \"minecraft:stone\"}},
-                    \"descriptions\": [\"A\"],
-                    \"extra_descriptions\": [\"EA\"]
-                  },
-                  \"child\": {
-                    \"title\": {\"text\": \"Child\"},
-                    \"icon\": {\"type\": \"texture\", \"data\": {\"texture\": \"minecraft:stone\"}},
-                    \"parent\": \"parent\",
-                    \"merge_description\": true,
-                    \"descriptions\": [\"B\"],
-                    \"extra_descriptions\": [\"EB\"]
-                  }
-                }
-                """;
-
-        var element = JsonElement.parseString(json, JsonPath.create("test"))
-                .getSuccess().orElseThrow();
-
-        var result = SkillDefinitionsConfig.parse(element, new DummyContext());
-        Assertions.assertTrue(result.getSuccess().isPresent(),
-                result.getFailure().map(Object::toString).orElse("Unexpected failure"));
-        var defs = result.getSuccess().orElseThrow();
-        var child = defs.getById("child").orElseThrow();
-        Assertions.assertEquals(2, child.descriptions().size());
-        Assertions.assertEquals(2, child.extraDescriptions().size());
-        Assertions.assertEquals("A", child.descriptions().get(0).getString());
-        Assertions.assertEquals("EA", child.extraDescriptions().get(0).getString());
-    }
 }


### PR DESCRIPTION
## Summary
- drop parent field from `SkillDefinitionConfig`
- simplify `SkillDefinitionsConfig` parsing to skip inheritance merging
- remove parent merge test

## Testing
- `./gradlew :Common:test --no-daemon` *(fails: Execution failed for task ':Common:compileJava')*

------
https://chatgpt.com/codex/tasks/task_e_688a469e11d88327aa3a4d43f8ec687c