### PR TITLE
Add multiline tooltip test and fix build issues

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionsConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionsConfig.java
@@ -47,12 +47,12 @@ public class SkillDefinitionsConfig {
                         return merged.get(id);
                 }
                 if (!visiting.add(id)) {
-                        problems.add(Problem.of("Cycle in skill definition inheritance at '" + id + "'"));
+                        problems.add(Problem.message("Cycle in skill definition inheritance at '" + id + "'"));
                         return null;
                 }
                 var def = all.get(id);
                 if (def == null) {
-                        problems.add(Problem.of("Unknown skill definition '" + id + "'"));
+                        problems.add(Problem.message("Unknown skill definition '" + id + "'"));
                         return null;
                 }
                 java.util.List<net.minecraft.text.Text> descriptions = def.descriptions();

--- a/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
@@ -15,6 +15,7 @@ import net.puffish.skillsmod.util.PointSources;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class CategoryData {

--- a/Common/src/test/java/net/puffish/skillsmod/config/SkillDefinitionConfigTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/config/SkillDefinitionConfigTest.java
@@ -77,4 +77,45 @@ public class SkillDefinitionConfigTest {
         Assertions.assertEquals("A", child.descriptions().get(0).getString());
         Assertions.assertEquals("EA", child.extraDescriptions().get(0).getString());
     }
+
+    @Test
+    public void testMultiLineMergeDescription() {
+        String json = """
+                {
+                  \"base\": {
+                    \"title\": {\"text\": \"Base\"},
+                    \"icon\": {\"type\": \"texture\", \"data\": {\"texture\": \"minecraft:stone\"}},
+                    \"descriptions\": [\"A1\", \"A2\"],
+                    \"extra_descriptions\": [\"EA1\", \"EA2\"]
+                  },
+                  \"child\": {
+                    \"title\": {\"text\": \"Child\"},
+                    \"icon\": {\"type\": \"texture\", \"data\": {\"texture\": \"minecraft:stone\"}},
+                    \"parent\": \"base\",
+                    \"merge_description\": true,
+                    \"descriptions\": [\"B1\", \"B2\"],
+                    \"extra_descriptions\": [\"EB1\", \"EB2\"]
+                  }
+                }
+                """;
+
+        var element = JsonElement.parseString(json, JsonPath.create("test"))
+                .getSuccess().orElseThrow();
+
+        var result = SkillDefinitionsConfig.parse(element, new DummyContext());
+        Assertions.assertTrue(result.getSuccess().isPresent(),
+                result.getFailure().map(Object::toString).orElse("Unexpected failure"));
+        var defs = result.getSuccess().orElseThrow();
+        var child = defs.getById("child").orElseThrow();
+        Assertions.assertEquals(4, child.descriptions().size());
+        Assertions.assertEquals(4, child.extraDescriptions().size());
+        Assertions.assertEquals("A1", child.descriptions().get(0).getString());
+        Assertions.assertEquals("A2", child.descriptions().get(1).getString());
+        Assertions.assertEquals("B1", child.descriptions().get(2).getString());
+        Assertions.assertEquals("B2", child.descriptions().get(3).getString());
+        Assertions.assertEquals("EA1", child.extraDescriptions().get(0).getString());
+        Assertions.assertEquals("EA2", child.extraDescriptions().get(1).getString());
+        Assertions.assertEquals("EB1", child.extraDescriptions().get(2).getString());
+        Assertions.assertEquals("EB2", child.extraDescriptions().get(3).getString());
+    }
 }


### PR DESCRIPTION
## Summary
- ensure skill descriptions merge correctly when `merge_description` is true
- fix compilation errors in `CategoryData` and `SkillDefinitionsConfig`

## Testing
- `./gradlew clean test`

------
https://chatgpt.com/codex/tasks/task_e_688a46a013388327b824d9644cfe174c