### PR TITLE
Validate per-level reward params

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
@@ -66,10 +66,32 @@ public class PerLevelRewardsReward implements Reward {
 		}
 	});
 
-	// Access optional fields to avoid unused warnings
+	// Access optional fields and validate values
 	rootObject.get("skill_id");
-	rootObject.get("max_level");
-	rootObject.get("points_per_level");
+	
+	var optMaxLevel = rootObject.get("max_level")
+	.getSuccess() // ignore failure because this property is optional
+	.flatMap(element -> element.getAsInt()
+	.ifFailure(problems::add)
+	.getSuccess());
+	optMaxLevel.ifPresent(maxLevel -> {
+	if (maxLevel < 1) {
+	problems.add(rootObject.getPath().getObject("max_level")
+	.createProblem("Expected a value \u2265 1"));
+	}
+	});
+	
+	var optPointsPerLevel = rootObject.get("points_per_level")
+	.getSuccess() // ignore failure because this property is optional
+	.flatMap(element -> element.getAsInt()
+	.ifFailure(problems::add)
+	.getSuccess());
+	optPointsPerLevel.ifPresent(points -> {
+	if (points < 0) {
+	problems.add(rootObject.getPath().getObject("points_per_level")
+	.createProblem("Expected a value \u2265 0"));
+	}
+	});
 
 	if (problems.isEmpty()) {
 		return Result.success(new PerLevelRewardsReward(levelRewards));

--- a/Common/src/test/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsRewardTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsRewardTest.java
@@ -1,0 +1,64 @@
+package net.puffish.skillsmod.reward.builtin;
+
+import net.minecraft.server.MinecraftServer;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonPath;
+import net.puffish.skillsmod.api.reward.RewardConfigContext;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PerLevelRewardsRewardTest {
+
+	private static class DummyContext implements RewardConfigContext {
+	    private final JsonElement data;
+
+	    private DummyContext(JsonElement data) {
+	        this.data = data;
+	    }
+
+	    @Override
+	    public MinecraftServer getServer() {
+	        return null;
+	    }
+
+	    @Override
+	    public void emitWarning(String message) {
+	        // ignore
+	    }
+
+	    @Override
+	    public Result<JsonElement, Problem> getData() {
+	        return Result.success(data);
+	    }
+	}
+
+	private static Result<PerLevelRewardsReward, Problem> parse(String json) {
+	    var element = JsonElement.parseString(json, JsonPath.create("test"))
+	            .getSuccess().orElseThrow();
+	    return PerLevelRewardsReward.parse(new DummyContext(element));
+	}
+
+	@Test
+	public void testValidValues() {
+	    String json = "{\"skill_id\":\"s\",\"max_level\":1,\"points_per_level\":0,\"levels\":{\"1\":[]}}";
+	    var result = parse(json);
+	    Assertions.assertTrue(result.getSuccess().isPresent(),
+	            result.getFailure().map(Object::toString).orElse("Unexpected failure"));
+	}
+
+	@Test
+	public void testInvalidMaxLevel() {
+	    String json = "{\"skill_id\":\"s\",\"max_level\":0,\"points_per_level\":0,\"levels\":{\"1\":[]}}";
+	    var result = parse(json);
+	    Assertions.assertTrue(result.getFailure().isPresent());
+	}
+
+	@Test
+	public void testInvalidPointsPerLevel() {
+	    String json = "{\"skill_id\":\"s\",\"max_level\":1,\"points_per_level\":-1,\"levels\":{\"1\":[]}}";
+	    var result = parse(json);
+	    Assertions.assertTrue(result.getFailure().isPresent());
+	}
+}


### PR DESCRIPTION
## Summary
- validate points configuration when parsing `PerLevelRewardsReward`
- add a new `PerLevelRewardsRewardTest` covering valid and invalid values

## Testing
- `./gradlew :Common:test` *(fails: Execution failed for task ':Common:compileJava')*

------
https://chatgpt.com/codex/tasks/task_e_688a46da153c8327b4df1153bcf049ed