### PR TITLE
Remove inheritance from skill definitions

### DIFF
--- a/Common/src/main/java/net/puffish/skill_leveling/config/skill/SkillDefinitionsConfig.java
+++ b/Common/src/main/java/net/puffish/skill_leveling/config/skill/SkillDefinitionsConfig.java
@@ -25,74 +25,7 @@ public class SkillDefinitionsConfig {
         public static Result<SkillDefinitionsConfig, Problem> parse(JsonObject rootObject, ConfigContext context) {
                 return rootObject.getAsMap((id, element) -> SkillDefinitionConfig.parse(id, element, context))
                                 .mapFailure(problems -> Problem.combine(problems.values()))
-                                .andThen(map -> {
-                                        var problems = new java.util.ArrayList<Problem>();
-                                        var merged = new java.util.HashMap<String, SkillDefinitionConfig>();
-                                        for (var entry : map.entrySet()) {
-                                                merge(entry.getKey(), map, merged, new java.util.HashSet<>(), problems);
-                                        }
-                                        if (problems.isEmpty()) {
-                                                return Result.success(new SkillDefinitionsConfig(merged));
-                                        } else {
-                                                return Result.failure(Problem.combine(problems));
-                                        }
-                                });
-        }
-
-        private static SkillDefinitionConfig merge(String id, Map<String, SkillDefinitionConfig> all,
-                                    Map<String, SkillDefinitionConfig> merged,
-                                    java.util.Set<String> visiting,
-                                    java.util.List<Problem> problems) {
-                if (merged.containsKey(id)) {
-                        return merged.get(id);
-                }
-                if (!visiting.add(id)) {
-                        problems.add(Problem.message("Cycle in skill definition inheritance at '" + id + "'"));
-                        return null;
-                }
-                var def = all.get(id);
-                if (def == null) {
-                        problems.add(Problem.message("Unknown skill definition '" + id + "'"));
-                        return null;
-                }
-                java.util.List<net.minecraft.text.Text> descriptions = def.descriptions();
-                java.util.List<net.minecraft.text.Text> extra = def.extraDescriptions();
-                if (def.mergeDescription() && def.parent().isPresent()) {
-                        var parentId = def.parent().get();
-                        var parentObj = merge(parentId, all, merged, visiting, problems);
-                        if (parentObj != null) {
-                                descriptions = new java.util.ArrayList<>(parentObj.descriptions());
-                                descriptions.addAll(def.descriptions());
-                                extra = new java.util.ArrayList<>(parentObj.extraDescriptions());
-                                extra.addAll(def.extraDescriptions());
-                        }
-                } else if (def.parent().isPresent()) {
-                        merge(def.parent().get(), all, merged, visiting, problems);
-                }
-                visiting.remove(id);
-
-                var mergedDef = new SkillDefinitionConfig(
-                                def.id(),
-                                def.parent(),
-                                def.type(),
-                                def.maxLevels(),
-                                descriptions,
-                                extra,
-                                def.title(),
-                                def.icon(),
-                                def.frame(),
-                                def.size(),
-                                def.mergeDescription(),
-                                def.rewards(),
-                                def.cost(),
-                                def.requiredSkills(),
-                                def.requiredPoints(),
-                                def.requiredSpentPoints(),
-                                def.requiredExclusions()
-                );
-                merged.put(id, mergedDef);
-                return mergedDef;
-
+                                .map(SkillDefinitionsConfig::new);
         }
 
 	public Optional<SkillDefinitionConfig> getById(String id) {

--- a/Common/src/test/java/net/puffish/skillsmod/config/SkillDefinitionConfigTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/config/SkillDefinitionConfigTest.java
@@ -71,10 +71,10 @@ public class SkillDefinitionConfigTest {
                 result.getFailure().map(Object::toString).orElse("Unexpected failure"));
         var defs = result.getSuccess().orElseThrow();
         var child = defs.getById("child").orElseThrow();
-        Assertions.assertEquals(2, child.descriptions().size());
-        Assertions.assertEquals(2, child.extraDescriptions().size());
-        Assertions.assertEquals("A", child.descriptions().get(0).getString());
-        Assertions.assertEquals("EA", child.extraDescriptions().get(0).getString());
+        Assertions.assertEquals(1, child.descriptions().size());
+        Assertions.assertEquals(1, child.extraDescriptions().size());
+        Assertions.assertEquals("B", child.descriptions().get(0).getString());
+        Assertions.assertEquals("EB", child.extraDescriptions().get(0).getString());
     }
 
     @Test
@@ -106,15 +106,11 @@ public class SkillDefinitionConfigTest {
                 result.getFailure().map(Object::toString).orElse("Unexpected failure"));
         var defs = result.getSuccess().orElseThrow();
         var child = defs.getById("child").orElseThrow();
-        Assertions.assertEquals(4, child.descriptions().size());
-        Assertions.assertEquals(4, child.extraDescriptions().size());
-        Assertions.assertEquals("A1", child.descriptions().get(0).getString());
-        Assertions.assertEquals("A2", child.descriptions().get(1).getString());
-        Assertions.assertEquals("B1", child.descriptions().get(2).getString());
-        Assertions.assertEquals("B2", child.descriptions().get(3).getString());
-        Assertions.assertEquals("EA1", child.extraDescriptions().get(0).getString());
-        Assertions.assertEquals("EA2", child.extraDescriptions().get(1).getString());
-        Assertions.assertEquals("EB1", child.extraDescriptions().get(2).getString());
-        Assertions.assertEquals("EB2", child.extraDescriptions().get(3).getString());
+        Assertions.assertEquals(2, child.descriptions().size());
+        Assertions.assertEquals(2, child.extraDescriptions().size());
+        Assertions.assertEquals("B1", child.descriptions().get(0).getString());
+        Assertions.assertEquals("B2", child.descriptions().get(1).getString());
+        Assertions.assertEquals("EB1", child.extraDescriptions().get(0).getString());
+        Assertions.assertEquals("EB2", child.extraDescriptions().get(1).getString());
     }
 }


### PR DESCRIPTION
## Summary
- simplify `SkillDefinitionsConfig` to drop inheritance logic
- adjust tests to match the new behaviour

## Testing
- `./gradlew help --no-daemon` *(fails: fabric-installer.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a76fec39c8327923b4d08f873ff38