### PR TITLE
Add missing MutableText import

### DIFF
--- a/Common/src/main/java/net/puffish/skill_leveling/client/gui/SkillsScreen.java
+++ b/Common/src/main/java/net/puffish/skill_leveling/client/gui/SkillsScreen.java
@@ -9,6 +9,7 @@ import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.widget.ToggleButtonWidget;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;


### PR DESCRIPTION
## Summary
- fix SkillsScreen imports by including MutableText

## Testing
- `./gradlew build` *(fails: `fabric-installer.json not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688a7700a72c8327885d7a8a4a93e366