### PR TITLE
Fix compile error in SkillDefinitionsConfig

### DIFF
--- a/Common/src/main/java/net/puffish/skill_leveling/config/skill/SkillDefinitionsConfig.java
+++ b/Common/src/main/java/net/puffish/skill_leveling/config/skill/SkillDefinitionsConfig.java
@@ -23,9 +23,9 @@ public class SkillDefinitionsConfig {
 	}
 
         public static Result<SkillDefinitionsConfig, Problem> parse(JsonObject rootObject, ConfigContext context) {
-                return rootObject.getAsMap((id, element) -> SkillDefinitionConfig.parse(id, element, context))
-                                .mapFailure(problems -> Problem.combine(problems.values()))
-                                .map(SkillDefinitionsConfig::new);
+               return rootObject.getAsMap((id, element) -> SkillDefinitionConfig.parse(id, element, context))
+                               .mapFailure(problems -> Problem.combine(problems.values()))
+                               .mapSuccess(SkillDefinitionsConfig::new);
         }
 
 	public Optional<SkillDefinitionConfig> getById(String id) {


### PR DESCRIPTION
## Summary
- correct the Result mapping method in `SkillDefinitionsConfig`

## Testing
- `./gradlew :Common:compileJava --no-daemon --info` *(fails to fully run due to environment limits but shows compilation proceeding)*

------
https://chatgpt.com/codex/tasks/task_e_688aaf8268348327a7490a63a7e5743e