### PR TITLE
Add skill refund command

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -320,10 +320,10 @@ public class SkillsMod {
                 });
         }
 
-	public void lockSkill(ServerPlayerEntity player, Identifier categoryId, String skillId) {
-		getCategory(categoryId).ifPresent(category -> {
-			var categoryData = getPlayerData(player).getOrCreateCategoryData(category);
-			category.skills().getById(skillId).ifPresent(skill -> {
+        public void lockSkill(ServerPlayerEntity player, Identifier categoryId, String skillId) {
+                getCategory(categoryId).ifPresent(category -> {
+                        var categoryData = getPlayerData(player).getOrCreateCategoryData(category);
+                        category.skills().getById(skillId).ifPresent(skill -> {
                                 int prevLevel = categoryData.getSkillLevel(skillId);
                                 watchNewPoints(player, category, categoryData, false, () -> {
                                         categoryData.lockSkill(skillId);
@@ -332,6 +332,33 @@ public class SkillsMod {
                                 });
                                 SKILL_LOCK.invoker().onSkillLock(categoryId, skillId);
                                 updateSkillRewards(player, category, categoryData, skill, -prevLevel);
+                        });
+                });
+        }
+
+        public void refundSkill(ServerPlayerEntity player, Identifier categoryId, String skillId, boolean all) {
+                getCategory(categoryId).ifPresent(category -> {
+                        var categoryData = getPlayerData(player).getOrCreateCategoryData(category);
+                        category.skills().getById(skillId).ifPresent(skill -> {
+                                int prevLevel = categoryData.getSkillLevel(skillId);
+                                if (prevLevel <= 0) {
+                                        return;
+                                }
+                                int amount = all ? prevLevel : 1;
+                                watchNewPoints(player, category, categoryData, false, () -> {
+                                        if (all) {
+                                                categoryData.lockSkill(skillId);
+                                                packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, false));
+                                        } else {
+                                                categoryData.refundSkill(skillId);
+                                                packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, true));
+                                        }
+                                        syncPoints(player, category, categoryData);
+                                });
+                                if (all || prevLevel - amount <= 0) {
+                                        SKILL_LOCK.invoker().onSkillLock(categoryId, skillId);
+                                }
+                                updateSkillRewards(player, category, categoryData, skill, -amount);
                         });
                 });
         }

--- a/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
+++ b/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
@@ -9,6 +9,7 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.puffish.skillsmod.commands.arguments.CategoryArgumentType;
 import net.puffish.skillsmod.commands.arguments.SkillArgumentType;
 import net.puffish.skillsmod.util.CommandUtils;
+import net.puffish.skillsmod.SkillsMod;
 
 public class SkillsCommand {
 	public static LiteralArgumentBuilder<ServerCommandSource> create() {
@@ -32,14 +33,26 @@ public class SkillsCommand {
 								)
 						)
 				)
-				.then(CommandManager.literal("reset")
-						.then(CommandManager.argument("players", EntityArgumentType.players())
-								.then(CommandManager.argument("category", CategoryArgumentType.category())
-										.executes(SkillsCommand::reset)
-								)
-						)
-				);
-	}
+                                .then(CommandManager.literal("reset")
+                                                .then(CommandManager.argument("players", EntityArgumentType.players())
+                                                                .then(CommandManager.argument("category", CategoryArgumentType.category())
+                                                                                .executes(SkillsCommand::reset)
+                                                                )
+                                                )
+                                )
+                                .then(CommandManager.literal("refund")
+                                                .then(CommandManager.argument("players", EntityArgumentType.players())
+                                                                .then(CommandManager.argument("category", CategoryArgumentType.category())
+                                                                                .then(CommandManager.argument("skill", SkillArgumentType.skillFromCategory("category"))
+                                                                                                .executes(ctx -> refund(ctx, false))
+                                                                                                .then(CommandManager.literal("all")
+                                                                                                                .executes(ctx -> refund(ctx, true))
+                                                                                                )
+                                                                                )
+                                                                )
+                                                )
+                                );
+        }
 
 	private static int unlock(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
 		var players = EntityArgumentType.getPlayers(context, "players");
@@ -77,9 +90,9 @@ public class SkillsCommand {
 		return players.size();
 	}
 
-	private static int reset(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-		var players = EntityArgumentType.getPlayers(context, "players");
-		var category = CategoryArgumentType.getCategory(context, "category");
+        private static int reset(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+                var players = EntityArgumentType.getPlayers(context, "players");
+                var category = CategoryArgumentType.getCategory(context, "category");
 
 		for (var player : players) {
 			category.resetSkills(player);
@@ -90,6 +103,24 @@ public class SkillsCommand {
 				"skills.reset",
 				category.getId()
 		);
-		return players.size();
-	}
+                return players.size();
+        }
+
+        private static int refund(CommandContext<ServerCommandSource> context, boolean all) throws CommandSyntaxException {
+                var players = EntityArgumentType.getPlayers(context, "players");
+                var category = CategoryArgumentType.getCategory(context, "category");
+                var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
+
+                for (var player : players) {
+                        SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId(), all);
+                }
+                CommandUtils.sendSuccess(
+                                context,
+                                players,
+                                all ? "skills.refund_all" : "skills.refund",
+                                category.getId(),
+                                skill.getId()
+                );
+                return players.size();
+        }
 }

--- a/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
@@ -173,6 +173,15 @@ public class CategoryData {
                unlockedSkills.remove(id);
        }
 
+       public void refundSkill(String id) {
+               unlockedSkills.compute(id, (k, v) -> {
+                       if (v == null || v <= 1) {
+                               return null;
+                       }
+                       return v - 1;
+               });
+       }
+
        public int getSkillLevel(String id) {
                return unlockedSkills.getOrDefault(id, 0);
        }

--- a/Common/src/main/resources/assets/puffish_skills/lang/en_us.json
+++ b/Common/src/main/resources/assets/puffish_skills/lang/en_us.json
@@ -52,7 +52,12 @@
 	"command.puffish_skills.skills.unlock.success.multiple": "Unlocked %s skill in category %s for %s players",
 
 	"command.puffish_skills.skills.lock.success.single": "Locked %s skill in category %s for %s",
-	"command.puffish_skills.skills.lock.success.multiple": "Locked %s skill in category %s for %s players",
+        "command.puffish_skills.skills.lock.success.multiple": "Locked %s skill in category %s for %s players",
+
+        "command.puffish_skills.skills.refund.success.single": "Refunded one level of %s skill in category %s for %s",
+        "command.puffish_skills.skills.refund.success.multiple": "Refunded one level of %s skill in category %s for %s players",
+        "command.puffish_skills.skills.refund_all.success.single": "Refunded all levels of %s skill in category %s for %s",
+        "command.puffish_skills.skills.refund_all.success.multiple": "Refunded all levels of %s skill in category %s for %s players",
 
 	"command.puffish_skills.skills.reset.success.single": "Reset all skills in category %s for %s",
 	"command.puffish_skills.skills.reset.success.multiple": "Reset all skills in category %s for %s players",

--- a/README.md
+++ b/README.md
@@ -91,3 +91,14 @@ All active level rewards stack automatically, so unlocking additional levels inc
 
 The `example-skill-level-template.zip` file contains a datapack demonstrating a stackable skill using per-level rewards. Drop the zip into the `datapacks` folder of a world to test the feature.
 
+
+
+## Commands
+
+Administrators can refund skill levels using `/puffish_skills skills refund`.
+
+```
+/puffish_skills skills refund <players> <category> <skill> [all]
+```
+
+Running without `all` refunds a single level. Adding `all` removes every level of the chosen skill.


### PR DESCRIPTION
## Summary
- add `refundSkill` logic to decrease skill levels
- support refund via `/skills refund` command
- add translations for refund messages
- document refund command in the README

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688bd5c24e8c8327a438b5f6d9d05197