### PR TITLE
Fix missing EnvType compile warnings

### DIFF
--- a/Common/build.gradle.kts
+++ b/Common/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     mappings("net.fabricmc:yarn:${project.properties["yarn_mappings"]}:v2")
 
     compileOnly("net.fabricmc:sponge-mixin:${project.properties["mixin_version"]}")
+    // Provide EnvType and other loader classes used by the mapped Mojang sources
+    compileOnly("net.fabricmc:fabric-loader:${project.properties["fabric_loader_version"]}")
 
     testImplementation("org.junit.jupiter:junit-jupiter:${project.properties["junit_version"]}")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ archives_base_name = puffish_skills
 # Dependencies
 mixin_version = 0.12.4+mixin.0.8.5
 junit_version = 5.7.1
+fabric_loader_version=0.14.21


### PR DESCRIPTION
## Summary
- include Fabric loader in the `Common` compile classpath
- share `fabric_loader_version` property across modules

## Testing
- `./gradlew build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688c18cfb1ac8327a2085114012b3665