### PR TITLE
Fix refund command and description merging

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -336,32 +336,33 @@ public class SkillsMod {
                 });
         }
 
-        public void refundSkill(ServerPlayerEntity player, Identifier categoryId, String skillId, boolean all) {
-                getCategory(categoryId).ifPresent(category -> {
-                        var categoryData = getPlayerData(player).getOrCreateCategoryData(category);
-                        category.skills().getById(skillId).ifPresent(skill -> {
-                                int prevLevel = categoryData.getSkillLevel(skillId);
-                                if (prevLevel <= 0) {
-                                        return;
-                                }
-                                int amount = all ? prevLevel : 1;
-                                watchNewPoints(player, category, categoryData, false, () -> {
-                                        if (all) {
-                                                categoryData.lockSkill(skillId);
-                                                packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, false));
-                                        } else {
-                                                categoryData.refundSkill(skillId);
-                                                packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, true));
-                                        }
-                                        syncPoints(player, category, categoryData);
-                                });
-                                if (all || prevLevel - amount <= 0) {
-                                        SKILL_LOCK.invoker().onSkillLock(categoryId, skillId);
-                                }
-                                updateSkillRewards(player, category, categoryData, skill, -amount);
-                        });
-                });
-        }
+       public boolean refundSkill(ServerPlayerEntity player, Identifier categoryId, String skillId, boolean all) {
+               return getCategory(categoryId).map(category -> {
+                       var categoryData = getPlayerData(player).getOrCreateCategoryData(category);
+                       return category.skills().getById(skillId).map(skill -> {
+                               int prevLevel = categoryData.getSkillLevel(skillId);
+                               if (prevLevel <= 0) {
+                                       return false;
+                               }
+                               int amount = all ? prevLevel : 1;
+                               watchNewPoints(player, category, categoryData, false, () -> {
+                                       if (all) {
+                                               categoryData.lockSkill(skillId);
+                                               packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, false));
+                                       } else {
+                                               categoryData.refundSkill(skillId);
+                                               packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, true));
+                                       }
+                                       syncPoints(player, category, categoryData);
+                               });
+                               if (all || prevLevel - amount <= 0) {
+                                       SKILL_LOCK.invoker().onSkillLock(categoryId, skillId);
+                               }
+                               updateSkillRewards(player, category, categoryData, skill, -amount);
+                               return true;
+                       }).orElse(false);
+               }).orElse(false);
+       }
 
         public void resetSkills(ServerPlayerEntity player, Identifier categoryId) {
                 getCategory(categoryId).ifPresent(category -> {

--- a/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
@@ -678,7 +678,7 @@ public class SkillsScreen extends Screen {
                                 var descIndex = Math.min(level, definition.descriptions().size() - 1);
                                 MutableText desc = Text.empty();
                                 if (!definition.descriptions().isEmpty()) {
-                                        if (definition.mergeDescription()) {
+                                        if (definition.mergeDescription() && level > 1) {
                                                 for (int i = 0; i <= descIndex; i++) {
                                                         if (i > 0) {
                                                                 desc.append(Text.literal("\n"));
@@ -697,7 +697,7 @@ public class SkillsScreen extends Screen {
                                         var extraIndex = Math.min(level, definition.extraDescriptions().size() - 1);
                                         MutableText extraDesc = Text.empty();
                                         if (!definition.extraDescriptions().isEmpty()) {
-                                                if (definition.mergeDescription()) {
+                                                if (definition.mergeDescription() && level > 1) {
                                                         for (int i = 0; i <= extraIndex; i++) {
                                                                 if (i > 0) {
                                                                         extraDesc.append(Text.literal("\n"));

--- a/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
+++ b/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
@@ -106,21 +106,33 @@ public class SkillsCommand {
                 return players.size();
         }
 
-        private static int refund(CommandContext<ServerCommandSource> context, boolean all) throws CommandSyntaxException {
-                var players = EntityArgumentType.getPlayers(context, "players");
-                var category = CategoryArgumentType.getCategory(context, "category");
-                var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
+       private static int refund(CommandContext<ServerCommandSource> context, boolean all) throws CommandSyntaxException {
+               var players = EntityArgumentType.getPlayers(context, "players");
+               var category = CategoryArgumentType.getCategory(context, "category");
+               var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
 
-                for (var player : players) {
-                        SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId(), all);
-                }
-                CommandUtils.sendSuccess(
-                                context,
-                                players,
-                                all ? "skills.refund_all" : "skills.refund",
-                                category.getId(),
-                                skill.getId()
-                );
-                return players.size();
-        }
+               var refunded = false;
+               for (var player : players) {
+                       refunded |= SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId(), all);
+               }
+
+               if (refunded) {
+                       CommandUtils.sendSuccess(
+                                       context,
+                                       players,
+                                       all ? "skills.refund_all" : "skills.refund",
+                                       category.getId(),
+                                       skill.getId()
+                       );
+                       return players.size();
+               } else {
+                       context.getSource().sendError(SkillsMod.createTranslatable(
+                                       "command",
+                                       "skills.refund.no_levels",
+                                       category.getId(),
+                                       skill.getId()
+                       ));
+                       return 0;
+               }
+       }
 }

--- a/Common/src/main/resources/assets/puffish_skills/lang/en_us.json
+++ b/Common/src/main/resources/assets/puffish_skills/lang/en_us.json
@@ -58,8 +58,9 @@
         "command.puffish_skills.skills.refund.success.multiple": "Refunded one level of %s skill in category %s for %s players",
         "command.puffish_skills.skills.refund_all.success.single": "Refunded all levels of %s skill in category %s for %s",
         "command.puffish_skills.skills.refund_all.success.multiple": "Refunded all levels of %s skill in category %s for %s players",
+        "command.puffish_skills.skills.refund.no_levels": "None of the selected players had any levels of %s skill in category %s to refund.",
 
-	"command.puffish_skills.skills.reset.success.single": "Reset all skills in category %s for %s",
+        "command.puffish_skills.skills.reset.success.single": "Reset all skills in category %s for %s",
 	"command.puffish_skills.skills.reset.success.multiple": "Reset all skills in category %s for %s players",
 
 	"command.puffish_skills.category.open.success.single": "Opened category %s screen for %s",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Skill definitions describe how a skill looks and what it grants. Datapacks may n
   its rewards can be obtained.
 - `descriptions` – list of tooltip lines shown for each level.
 - `extra_descriptions` – list of extra tooltip lines (displayed while holding Shift).
-- `merge_description` – when `true`, descriptions and extra descriptions accumulate from earlier levels instead of replacing them. Defaults to `false` when omitted.
+- `merge_description` – when `true`, descriptions and extra descriptions accumulate from earlier levels instead of replacing them. Defaults to `false` when omitted. The first unlocked level shows only its own description, and earlier levels are merged once level 2 or higher is reached.
 
 - Tooltip lines automatically adjust based on how many times the skill has been unlocked. When hovering a skill, the
   entry matching the player's current level is shown, and holding Shift displays the line for the next level (or a final
@@ -101,4 +101,4 @@ Administrators can refund skill levels using `/puffish_skills skills refund`.
 /puffish_skills skills refund <players> <category> <skill> [all]
 ```
 
-Running without `all` refunds a single level. Adding `all` removes every level of the chosen skill.
+Running without `all` refunds a single level. Adding `all` removes every level of the chosen skill. The command can be repeated as needed and reports an error if none of the selected players have any levels to refund.


### PR DESCRIPTION
## Summary
- allow repeated skill refunds and report when no levels can be refunded
- show level 1 description on its own before merging with later levels
- document new behavior in README
- add feedback translation

## Testing
- `./gradlew build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688c266c729c83278b67f573a9afea5f