### PR TITLE
Fix description merging and refund logic

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
@@ -675,14 +675,12 @@ public class SkillsScreen extends Screen {
                                                 level,
                                                 definition.maxLevels()
                                 ).asOrderedText());
-                                var descIndex = Math.min(level, definition.descriptions().size() - 1);
+                                var descIndex = Math.min(Math.max(level - 1, 0), definition.descriptions().size() - 1);
                                 MutableText desc = Text.empty();
                                 if (!definition.descriptions().isEmpty()) {
-                                        if (definition.mergeDescription()) {
-                                                int start = (level <= 1) ? descIndex : 1;
-                                                start = Math.min(start, descIndex);
-                                                for (int i = start; i <= descIndex; i++) {
-                                                        if (i > start) {
+                                        if (definition.mergeDescription() && level > 1) {
+                                                for (int i = 0; i <= descIndex; i++) {
+                                                        if (i > 0) {
                                                                 desc.append(Text.literal("\n"));
                                                         }
                                                         desc.append(definition.descriptions().get(i).copy());
@@ -696,14 +694,12 @@ public class SkillsScreen extends Screen {
                                                 Style.EMPTY.withFormatting(Formatting.GRAY)
                                 )));
                                 if (Screen.hasShiftDown()) {
-                                        var extraIndex = Math.min(level, definition.extraDescriptions().size() - 1);
+                                        var extraIndex = Math.min(Math.max(level - 1, 0), definition.extraDescriptions().size() - 1);
                                         MutableText extraDesc = Text.empty();
-                                        if (!definition.extraDescriptions().isEmpty()) {                                      
-                                                if (definition.mergeDescription()) {
-                                                        int startExtra = (level <= 1) ? extraIndex : 1;
-                                                        startExtra = Math.min(startExtra, extraIndex);
-                                                        for (int i = startExtra; i <= extraIndex; i++) {
-                                                                if (i > startExtra) {
+                                        if (!definition.extraDescriptions().isEmpty()) {
+                                                if (definition.mergeDescription() && level > 1) {
+                                                        for (int i = 0; i <= extraIndex; i++) {
+                                                                if (i > 0) {
                                                                         extraDesc.append(Text.literal("\n"));
                                                                 }
                                                                 extraDesc.append(definition.extraDescriptions().get(i).copy());

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Skill definitions describe how a skill looks and what it grants. Datapacks may n
   its rewards can be obtained.
 - `descriptions` – list of tooltip lines shown for each level.
 - `extra_descriptions` – list of extra tooltip lines (displayed while holding Shift).
-- `merge_description` – when `true`, descriptions and extra descriptions start accumulating from level 2 onward instead of replacing them. The first level's tooltip is shown on its own for smoother progression. Defaults to `false` when omitted.
+- `merge_description` – when `true`, descriptions and extra descriptions accumulate from previous levels starting when level 2 is reached. The tooltip for the very first level is shown on its own. Defaults to `false` when omitted.
 - Tooltip lines automatically adjust based on how many times the skill has been unlocked. When hovering a skill, the
   entry matching the player's current level is shown, and holding Shift displays the line for the next level (or a final
   message if the skill is maxed).


### PR DESCRIPTION
## Summary
- correct off-by-one in skill description merging logic so level 1 keeps its own description
- update merging behaviour for extra descriptions
- clarify README note about merge_description option

## Testing
- `./gradlew build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688c32f768a48327801b75dadd0016fe