### PR TITLE
Fix refund command UI update

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -346,13 +346,14 @@ public class SkillsMod {
                                }
                                int amount = all ? prevLevel : 1;
                                watchNewPoints(player, category, categoryData, false, () -> {
+                                       boolean stillUnlocked;
                                        if (all) {
                                                categoryData.lockSkill(skillId);
-                                               packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, false));
+                                               stillUnlocked = false;
                                        } else {
-                                               categoryData.refundSkill(skillId);
-                                               packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, true));
+                                               stillUnlocked = categoryData.refundSkill(skillId);
                                        }
+                                       packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, stillUnlocked));
                                        syncPoints(player, category, categoryData);
                                });
                                if (all || prevLevel - amount <= 0) {

--- a/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
@@ -173,13 +173,18 @@ public class CategoryData {
                unlockedSkills.remove(id);
        }
 
-       public void refundSkill(String id) {
-               unlockedSkills.compute(id, (k, v) -> {
+       /**
+        * Reduces the skill level by one. Returns {@code true} if the skill
+        * still has remaining levels unlocked afterwards.
+        */
+       public boolean refundSkill(String id) {
+               Integer level = unlockedSkills.compute(id, (k, v) -> {
                        if (v == null || v <= 1) {
                                return null;
                        }
                        return v - 1;
                });
+               return level != null;
        }
 
        public int getSkillLevel(String id) {


### PR DESCRIPTION
## Summary
- return whether a skill stays unlocked after refunding it
- send correct skill state to clients when refunding a level

## Testing
- `./gradlew build`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_688c3799f49883279f89894cada06ecf