### PR TITLE
Fix skill refund logic and reward persistence

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -336,7 +336,7 @@ public class SkillsMod {
                 });
         }
 
-       public boolean refundSkill(ServerPlayerEntity player, Identifier categoryId, String skillId, boolean all) {
+       public boolean refundSkill(ServerPlayerEntity player, Identifier categoryId, String skillId) {
                return getCategory(categoryId).map(category -> {
                        var categoryData = getPlayerData(player).getOrCreateCategoryData(category);
                        return category.skills().getById(skillId).map(skill -> {
@@ -362,23 +362,16 @@ public class SkillsMod {
                                        }
                                }
 
-                               int amount = all ? prevLevel : 1;
                                var finalSkillId = refundSkillId;
                                watchNewPoints(player, category, categoryData, false, () -> {
-                                       boolean stillUnlocked;
-                                       if (all) {
-                                               categoryData.lockSkill(finalSkillId);
-                                               stillUnlocked = false;
-                                       } else {
-                                               stillUnlocked = categoryData.refundSkill(finalSkillId);
-                                       }
+                                       boolean stillUnlocked = categoryData.refundSkill(finalSkillId);
                                        packetSender.send(player, new SkillUpdateOutPacket(categoryId, finalSkillId, stillUnlocked));
                                        syncPoints(player, category, categoryData);
                                });
-                               if (all || prevLevel - amount <= 0) {
+                               if (prevLevel - 1 <= 0) {
                                        SKILL_LOCK.invoker().onSkillLock(categoryId, refundSkillId);
                                }
-                               updateSkillRewards(player, category, categoryData, refundSkill, -amount);
+                               updateSkillRewards(player, category, categoryData, refundSkill, -1);
                                return true;
                        }).orElse(false);
                }).orElse(false);

--- a/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
+++ b/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
@@ -44,10 +44,7 @@ public class SkillsCommand {
                                                 .then(CommandManager.argument("players", EntityArgumentType.players())
                                                                 .then(CommandManager.argument("category", CategoryArgumentType.category())
                                                                                 .then(CommandManager.argument("skill", SkillArgumentType.skillFromCategory("category"))
-                                                                                                .executes(ctx -> refund(ctx, false))
-                                                                                                .then(CommandManager.literal("all")
-                                                                                                                .executes(ctx -> refund(ctx, true))
-                                                                                                )
+                                                                                                .executes(SkillsCommand::refund)
                                                                                 )
                                                                 )
                                                 )
@@ -106,21 +103,21 @@ public class SkillsCommand {
                 return players.size();
         }
 
-       private static int refund(CommandContext<ServerCommandSource> context, boolean all) throws CommandSyntaxException {
+       private static int refund(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
                var players = EntityArgumentType.getPlayers(context, "players");
                var category = CategoryArgumentType.getCategory(context, "category");
                var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
 
                var refunded = false;
                for (var player : players) {
-                       refunded |= SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId(), all);
+                       refunded |= SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId());
                }
 
                if (refunded) {
                        CommandUtils.sendSuccess(
                                        context,
                                        players,
-                                       all ? "skills.refund_all" : "skills.refund",
+                                       "skills.refund",
                                        category.getId(),
                                        skill.getId()
                        );

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/CommandReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/CommandReward.java
@@ -109,22 +109,25 @@ public class CommandReward implements Reward {
 			executeCommand(player, command);
 		}
 
-		counts.compute(player.getUuid(), (uuid, count) -> {
-			if (count == null) {
-				count = 0;
-			}
+                counts.compute(player.getUuid(), (uuid, count) -> {
+                        if (count == null) {
+                                // initialize without executing commands to avoid
+                                // running unlock actions again when the player
+                                // rejoins the world
+                                return context.getCount();
+                        }
 
-			while (context.getCount() > count) {
-				executeCommand(player, unlockCommand);
-				count++;
-			}
-			while (context.getCount() < count) {
-				executeCommand(player, lockCommand);
-				count--;
-			}
+                        while (context.getCount() > count) {
+                                executeCommand(player, unlockCommand);
+                                count++;
+                        }
+                        while (context.getCount() < count) {
+                                executeCommand(player, lockCommand);
+                                count--;
+                        }
 
-			return count;
-		});
+                        return count;
+                });
 	}
 
 	@Override

--- a/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
@@ -99,10 +99,6 @@ public class CategoryData {
 
 	public Skill.State getSkillState(CategoryConfig category, SkillConfig skill, SkillDefinitionConfig definition) {
                var level = unlockedSkills.getOrDefault(skill.id(), 0);
-               var total = countUnlocked(category, definition.id());
-               if (total >= definition.maxLevels()) {
-                       return level > 0 ? Skill.State.UNLOCKED : Skill.State.LOCKED;
-               }
                if (level >= definition.maxLevels()) {
                        return Skill.State.UNLOCKED;
                }

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The `example-skill-level-template.zip` file contains a datapack demonstrating a 
 Administrators can refund skill levels using `/puffish_skills skills refund`.
 
 ```
-/puffish_skills skills refund <players> <category> <skill> [all]
+/puffish_skills skills refund <players> <category> <skill>
 ```
 
-Running without `all` refunds a single level. Adding `all` removes every level of the chosen skill. The command can be repeated as needed and reports an error if none of the selected players have any levels to refund.
+This command refunds a single level of the chosen skill. It can be repeated as needed and reports an error if none of the selected players have any levels to refund.


### PR DESCRIPTION
## Summary
- avoid re-running command rewards on player join
- allow unlocking multiple skills per definition
- simplify refund command to remove optional `all` argument
- document updated refund command

## Testing
- `./gradlew build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688c9acae0108327b90c802ae14f4e63