### PR TITLE
Fix shared definitions and conditionally show skill levels

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -309,9 +309,9 @@ public class SkillsMod {
 			category.skills().getById(skillId).ifPresent(skill -> {
 				if (categoryData.canUnlockSkill(category, skill, force)) {
 					watchNewPoints(player, category, categoryData, false, () -> {
-						categoryData.unlockSkill(skillId);
-						packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, true));
-						syncPoints(player, category, categoryData);
+                                                categoryData.unlockSkill(skillId);
+                                                packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, true, categoryData.getSkillLevel(skillId)));
+                                                syncPoints(player, category, categoryData);
 					});
                                         SKILL_UNLOCK.invoker().onSkillUnlock(categoryId, skillId);
                                         updateSkillRewards(player, category, categoryData, skill, 1);
@@ -327,7 +327,7 @@ public class SkillsMod {
                                 int prevLevel = categoryData.getSkillLevel(skillId);
                                 watchNewPoints(player, category, categoryData, false, () -> {
                                         categoryData.lockSkill(skillId);
-                                        packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, false));
+                                        packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, false, 0));
                                         syncPoints(player, category, categoryData);
                                 });
                                 SKILL_LOCK.invoker().onSkillLock(categoryId, skillId);
@@ -365,7 +365,7 @@ public class SkillsMod {
                                var finalSkillId = refundSkillId;
                                watchNewPoints(player, category, categoryData, false, () -> {
                                        boolean stillUnlocked = categoryData.refundSkill(finalSkillId);
-                                       packetSender.send(player, new SkillUpdateOutPacket(categoryId, finalSkillId, stillUnlocked));
+                                       packetSender.send(player, new SkillUpdateOutPacket(categoryId, finalSkillId, stillUnlocked, categoryData.getSkillLevel(finalSkillId)));
                                        syncPoints(player, category, categoryData);
                                });
 

--- a/Common/src/main/java/net/puffish/skillsmod/client/SkillsClientMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/SkillsClientMod.java
@@ -126,14 +126,14 @@ public class SkillsClientMod {
 	}
 
 	private void onSkillUpdatePacket(SkillUpdateInPacket packet) {
-		screenData.getCategory(packet.getCategoryId()).ifPresent(category -> {
-			if (packet.isUnlocked()) {
-				category.unlock(packet.getSkillId());
-			} else {
-				category.lock(packet.getSkillId());
-			}
-		});
-	}
+                screenData.getCategory(packet.getCategoryId()).ifPresent(category -> {
+                        if (packet.isUnlocked()) {
+                                category.unlock(packet.getSkillId(), packet.getLevel());
+                        } else {
+                                category.lock(packet.getSkillId());
+                        }
+                });
+        }
 
 	private void onExperienceUpdatePacket(ExperienceUpdateInPacket packet) {
 		screenData.getCategory(packet.getCategoryId()).ifPresent(category -> {

--- a/Common/src/main/java/net/puffish/skillsmod/client/config/skill/ClientSkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/config/skill/ClientSkillDefinitionConfig.java
@@ -18,7 +18,8 @@ public record ClientSkillDefinitionConfig(
                 boolean mergeDescription,
                 int cost,
 		int requiredSkills,
-		int requiredPoints,
-		int requiredSpentPoints,
-		int requiredExclusions
+                int requiredPoints,
+                int requiredSpentPoints,
+                int requiredExclusions,
+                boolean hasLevelRewards
 ) { }

--- a/Common/src/main/java/net/puffish/skillsmod/client/data/ClientCategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/data/ClientCategoryData.java
@@ -14,8 +14,9 @@ import java.util.Optional;
 
 public class ClientCategoryData {
 	private final ClientCategoryConfig config;
-	private final Map<String, Skill.State> skillStates;
-	private final Map<ClientSkillConnectionConfig, ClientSkillConnectionData> connectionStates;
+        private final Map<String, Skill.State> skillStates;
+        private final Map<String, Integer> skillLevels;
+        private final Map<ClientSkillConnectionConfig, ClientSkillConnectionData> connectionStates;
 
 	private int spentPoints;
 	private int earnedPoints;
@@ -33,21 +34,23 @@ public class ClientCategoryData {
 
 	public ClientCategoryData(
 			ClientCategoryConfig config,
-			Map<String, Skill.State> skillStates,
-			int spentPoints,
-			int earnedPoints,
-			int currentLevel,
-			int currentExperience,
-			int requiredExperience
-	) {
-		this.config = config;
-		this.skillStates = skillStates;
-		this.spentPoints = spentPoints;
-		this.earnedPoints = earnedPoints;
-		this.currentLevel = currentLevel;
-		this.currentExperience = currentExperience;
-		this.requiredExperience = requiredExperience;
-		this.connectionStates = new HashMap<>();
+                        Map<String, Skill.State> skillStates,
+                        Map<String, Integer> skillLevels,
+                        int spentPoints,
+                        int earnedPoints,
+                        int currentLevel,
+                        int currentExperience,
+                        int requiredExperience
+        ) {
+                this.config = config;
+                this.skillStates = skillStates;
+                this.skillLevels = new HashMap<>(skillLevels);
+                this.spentPoints = spentPoints;
+                this.earnedPoints = earnedPoints;
+                this.currentLevel = currentLevel;
+                this.currentExperience = currentExperience;
+                this.requiredExperience = requiredExperience;
+                this.connectionStates = new HashMap<>();
 
 		for (var connection : config.normalConnections()) {
 			var skillA = config.skills().get(connection.skillAId());
@@ -98,23 +101,28 @@ public class ClientCategoryData {
 		return skillStates.get(skill.id());
 	}
 
-	public int countUnlocked(String definitionId) {
-		return (int) config.skills()
-				.values()
-				.stream()
-				.filter(skill -> skill.definitionId().equals(definitionId))
-				.filter(skill -> getSkillState(skill) == Skill.State.UNLOCKED)
-				.count();
-	}
+        public int countUnlocked(String definitionId) {
+                return config.skills()
+                                .values()
+                                .stream()
+                                .filter(skill -> skill.definitionId().equals(definitionId))
+                                .mapToInt(skill -> skillLevels.getOrDefault(skill.id(), 0))
+                                .sum();
+        }
 
-	public void unlock(String skillId) {
-		var skill = config.skills().get(skillId);
-		if (skill == null) {
-			return;
-		}
-		updateSkillState(skill, Skill.State.UNLOCKED);
-		if (skill.isRoot() && config.exclusiveRoot()) {
-			config.skills()
+        public int getSkillLevel(String skillId) {
+                return skillLevels.getOrDefault(skillId, 0);
+        }
+
+        public void unlock(String skillId, int level) {
+                var skill = config.skills().get(skillId);
+                if (skill == null) {
+                        return;
+                }
+                skillLevels.put(skillId, level);
+                updateSkillState(skill, Skill.State.UNLOCKED);
+                if (skill.isRoot() && config.exclusiveRoot()) {
+                        config.skills()
 					.values()
 					.stream()
 					.filter(ClientSkillConfig::isRoot)
@@ -158,14 +166,15 @@ public class ClientCategoryData {
 		}
 	}
 
-	public void lock(String skillId) {
-		var skill = config.skills().get(skillId);
-		if (skill == null) {
-			return;
-		}
-		if (isExcluded(skill)) {
-			updateSkillState(skill, Skill.State.EXCLUDED);
-		} else if (isAvailable(skill)) {
+        public void lock(String skillId) {
+                var skill = config.skills().get(skillId);
+                if (skill == null) {
+                        return;
+                }
+                skillLevels.remove(skillId);
+                if (isExcluded(skill)) {
+                        updateSkillState(skill, Skill.State.EXCLUDED);
+                } else if (isAvailable(skill)) {
 			if (isAffordable(skill)) {
 				updateSkillState(skill, Skill.State.AFFORDABLE);
 			} else {

--- a/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillsScreen.java
@@ -668,13 +668,15 @@ public class SkillsScreen extends Screen {
 				var lines = new ArrayList<OrderedText>();
 				lines.add(definition.title().asOrderedText());
 
-                                var level = activeCategoryData.countUnlocked(definition.id());
-                                lines.add(SkillsMod.createTranslatable(
-                                                "tooltip",
-                                                "skill_level",
-                                                level,
-                                                definition.maxLevels()
-                                ).asOrderedText());
+                                var level = activeCategoryData.getSkillLevel(hoveredSkill.id());
+                                if (definition.hasLevelRewards()) {
+                                        lines.add(SkillsMod.createTranslatable(
+                                                        "tooltip",
+                                                        "skill_level",
+                                                        level,
+                                                        definition.maxLevels()
+                                        ).asOrderedText());
+                                }
                                 var descIndex = Math.min(Math.max(level - 1, 0), definition.descriptions().size() - 1);
                                 MutableText desc = Text.empty();
                                 if (!definition.descriptions().isEmpty()) {

--- a/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/ShowCategoryInPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/ShowCategoryInPacket.java
@@ -21,6 +21,7 @@ import net.puffish.skillsmod.common.FrameType;
 import net.puffish.skillsmod.common.IconType;
 import net.puffish.skillsmod.network.InPacket;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ShowCategoryInPacket implements InPacket {
@@ -36,7 +37,7 @@ public class ShowCategoryInPacket implements InPacket {
 		return new ShowCategoryInPacket(category);
 	}
 
-	public static ClientCategoryData readCategory(PacketByteBuf buf) {
+        public static ClientCategoryData readCategory(PacketByteBuf buf) {
 		var id = buf.readIdentifier();
 
 		var title = buf.readText();
@@ -57,13 +58,21 @@ public class ShowCategoryInPacket implements InPacket {
 		var normalConnections = buf.readList(ShowCategoryInPacket::readSkillConnection);
 		var exclusiveConnections = buf.readList(ShowCategoryInPacket::readSkillConnection);
 
-		var skillsStates = buf.readMap(
-				PacketByteBuf::readString,
-				buf1 -> buf1.readEnumConstant(Skill.State.class)
-		);
+                var skillsInfo = buf.readMap(
+                                PacketByteBuf::readString,
+                                buf1 -> new SkillInfo(
+                                                buf1.readEnumConstant(Skill.State.class),
+                                                buf1.readInt()
+                                )
+                );
 
-		var spentPoints = buf.readInt();
-		var earnedPoints = buf.readInt();
+                var skillsStates = skillsInfo.entrySet().stream()
+                                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().state()));
+                var skillLevels = skillsInfo.entrySet().stream()
+                                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().level()));
+
+                var spentPoints = buf.readInt();
+                var earnedPoints = buf.readInt();
 
 		var levelLimit = Integer.MAX_VALUE;
 		var currentLevel = Integer.MIN_VALUE;
@@ -91,18 +100,21 @@ public class ShowCategoryInPacket implements InPacket {
 				exclusiveConnections
 		);
 
-		return new ClientCategoryData(
-				category,
-				skillsStates,
-				spentPoints,
-				earnedPoints,
-				currentLevel,
-				currentExperience,
-				requiredExperience
-		);
-	}
+                return new ClientCategoryData(
+                                category,
+                                skillsStates,
+                                skillLevels,
+                                spentPoints,
+                                earnedPoints,
+                                currentLevel,
+                                currentExperience,
+                                requiredExperience
+                );
+        }
 
-	public static ClientSkillDefinitionConfig readDefinition(PacketByteBuf buf) {
+        private record SkillInfo(Skill.State state, int level) { }
+
+        public static ClientSkillDefinitionConfig readDefinition(PacketByteBuf buf) {
 		var id = buf.readString();
 		var type = buf.readIdentifier();
 		var maxLevels = buf.readInt();
@@ -117,7 +129,8 @@ public class ShowCategoryInPacket implements InPacket {
 		var requiredSkills = buf.readInt();
 		var requiredPoints = buf.readInt();
 		var requiredSpentPoints = buf.readInt();
-		var requiredExclusions = buf.readInt();
+                var requiredExclusions = buf.readInt();
+                var hasLevelRewards = buf.readBoolean();
 
                 return new ClientSkillDefinitionConfig(
                         id,
@@ -132,12 +145,13 @@ public class ShowCategoryInPacket implements InPacket {
                         mergeDescription,
                         cost,
 
-				requiredSkills,
-				requiredPoints,
-				requiredSpentPoints,
-				requiredExclusions
-		);
-	}
+                                requiredSkills,
+                                requiredPoints,
+                                requiredSpentPoints,
+                                requiredExclusions,
+                                hasLevelRewards
+                );
+        }
 
 	public static ClientIconConfig readSkillIcon(PacketByteBuf buf) {
 		var type = buf.readEnumConstant(IconType.class);

--- a/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/SkillUpdateInPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/SkillUpdateInPacket.java
@@ -7,24 +7,28 @@ import net.puffish.skillsmod.network.InPacket;
 public class SkillUpdateInPacket implements InPacket {
 	private final Identifier categoryId;
 	private final String skillId;
-	private final boolean unlocked;
+        private final boolean unlocked;
+        private final int level;
 
-	private SkillUpdateInPacket(Identifier categoryId, String skillId, boolean unlocked) {
-		this.categoryId = categoryId;
-		this.skillId = skillId;
-		this.unlocked = unlocked;
-	}
+        private SkillUpdateInPacket(Identifier categoryId, String skillId, boolean unlocked, int level) {
+                this.categoryId = categoryId;
+                this.skillId = skillId;
+                this.unlocked = unlocked;
+                this.level = level;
+        }
 
-	public static SkillUpdateInPacket read(PacketByteBuf buf) {
-		var categoryId = buf.readIdentifier();
-		var skillId = buf.readString();
-		var unlocked = buf.readBoolean();
-		return new SkillUpdateInPacket(
-				categoryId,
-				skillId,
-				unlocked
-		);
-	}
+        public static SkillUpdateInPacket read(PacketByteBuf buf) {
+                var categoryId = buf.readIdentifier();
+                var skillId = buf.readString();
+                var unlocked = buf.readBoolean();
+                var level = buf.readInt();
+                return new SkillUpdateInPacket(
+                                categoryId,
+                                skillId,
+                                unlocked,
+                                level
+                );
+        }
 
 	public Identifier getCategoryId() {
 		return categoryId;
@@ -34,7 +38,11 @@ public class SkillUpdateInPacket implements InPacket {
 		return skillId;
 	}
 
-	public boolean isUnlocked() {
-		return unlocked;
-	}
+        public boolean isUnlocked() {
+                return unlocked;
+        }
+
+        public int getLevel() {
+                return level;
+        }
 }

--- a/Common/src/main/java/net/puffish/skillsmod/config/CategoryConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/CategoryConfig.java
@@ -12,6 +12,7 @@ import net.puffish.skillsmod.config.skill.SkillsConfig;
 import net.puffish.skillsmod.util.DisposeContext;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -56,25 +57,40 @@ public record CategoryConfig(
 						.getSuccess()
 		);
 
-		var optConnections = optSkills.flatMap(
-				skills -> SkillConnectionsConfig.parse(connectionsElement, skills, context)
-						.ifFailure(problems::add)
-						.getSuccess()
-		);
+                var optConnections = optSkills.flatMap(
+                                skills -> SkillConnectionsConfig.parse(connectionsElement, skills, context)
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                );
 
-		if (problems.isEmpty()) {
-			return Result.success(new CategoryConfig(
-					id,
-					optGeneral.orElseThrow(),
-					optDefinitions.orElseThrow(),
-					optSkills.orElseThrow(),
-					optConnections.orElseThrow(),
-					optExperience
-			));
-		} else {
-			return Result.failure(Problem.combine(problems));
-		}
-	}
+                if (problems.isEmpty()) {
+                        var definitionsCfg = optDefinitions.orElseThrow();
+                        var skillsCfg = optSkills.orElseThrow();
+
+                        var usedDefinitions = new HashSet<String>();
+                        skillsCfg.getAll().forEach(skill -> {
+                                if (!usedDefinitions.add(skill.definitionId())) {
+                                        problems.add(Problem.message("Skills must not share definitions"));
+                                }
+                        });
+                        definitionsCfg.getAll().forEach(definition -> {
+                                if (!usedDefinitions.contains(definition.id())) {
+                                        problems.add(Problem.message("Definition '" + definition.id() + "' is not used by any skill"));
+                                }
+                        });
+                        if (problems.isEmpty()) {
+                                return Result.success(new CategoryConfig(
+                                                id,
+                                                optGeneral.orElseThrow(),
+                                                definitionsCfg,
+                                                skillsCfg,
+                                                optConnections.orElseThrow(),
+                                                optExperience
+                                ));
+                        }
+                }
+                return Result.failure(Problem.combine(problems));
+        }
 
 	public void dispose(DisposeContext context) {
 		definitions.dispose(context);

--- a/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ShowCategoryOutPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ShowCategoryOutPacket.java
@@ -22,6 +22,7 @@ import net.puffish.skillsmod.config.skill.SkillDefinitionsConfig;
 import net.puffish.skillsmod.config.skill.SkillsConfig;
 import net.puffish.skillsmod.network.OutPacket;
 import net.puffish.skillsmod.network.Packets;
+import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
 import net.puffish.skillsmod.server.data.CategoryData;
 
 public record ShowCategoryOutPacket(CategoryConfig category, CategoryData categoryData) implements OutPacket {
@@ -33,17 +34,20 @@ public record ShowCategoryOutPacket(CategoryConfig category, CategoryData catego
 		write(buf, category.definitions());
 		write(buf, category.skills());
 		write(buf, category.connections());
-		buf.writeMap(
-				category.skills().getMap(),
-				PacketByteBuf::writeString,
-				(buf1, skill) -> buf1.writeEnumConstant(
-						categoryData.getSkillState(
-								category,
-								skill,
-								category.definitions().getById(skill.definitionId()).orElseThrow()
-						)
-				)
-		);
+                buf.writeMap(
+                                category.skills().getMap(),
+                                PacketByteBuf::writeString,
+                                (buf1, skill) -> {
+                                        buf1.writeEnumConstant(
+                                                        categoryData.getSkillState(
+                                                                        category,
+                                                                        skill,
+                                                                        category.definitions().getById(skill.definitionId()).orElseThrow()
+                                                        )
+                                        );
+                                        buf1.writeInt(categoryData.getSkillLevel(skill.id()));
+                                }
+                );
 		buf.writeInt(categoryData.getSpentPoints(category));
 		buf.writeInt(categoryData.getPointsTotal());
 		category.experience().ifPresentOrElse(experience -> {
@@ -85,7 +89,8 @@ public record ShowCategoryOutPacket(CategoryConfig category, CategoryData catego
 		buf.writeInt(definition.requiredSkills());
 		buf.writeInt(definition.requiredPoints());
 		buf.writeInt(definition.requiredSpentPoints());
-		buf.writeInt(definition.requiredExclusions());
+                buf.writeInt(definition.requiredExclusions());
+                buf.writeBoolean(definition.rewards().stream().anyMatch(reward -> reward.type().equals(PerLevelRewardsReward.ID)));
 	}
 
 	public void write(PacketByteBuf buf, SkillsConfig skills) {

--- a/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/SkillUpdateOutPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/SkillUpdateOutPacket.java
@@ -5,13 +5,14 @@ import net.minecraft.util.Identifier;
 import net.puffish.skillsmod.network.OutPacket;
 import net.puffish.skillsmod.network.Packets;
 
-public record SkillUpdateOutPacket(Identifier categoryId, String skillId, boolean unlocked) implements OutPacket {
+public record SkillUpdateOutPacket(Identifier categoryId, String skillId, boolean unlocked, int level) implements OutPacket {
 	@Override
 	public void write(PacketByteBuf buf) {
 		buf.writeIdentifier(categoryId);
 		buf.writeString(skillId);
-		buf.writeBoolean(unlocked);
-	}
+                buf.writeBoolean(unlocked);
+                buf.writeInt(level);
+        }
 
 	@Override
 	public Identifier getId() {


### PR DESCRIPTION
## Summary
- enforce one-definition-per-skill to avoid shared configuration issues
- track and transmit skill levels and per-level rewards to clients
- only show skill level tooltip when using `puffish_skills:per_level_rewards`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688d73f5a0b08327bedbe5995d1a0d91