### PR TITLE
fix: honor per-level reward caps and costs

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
@@ -11,6 +11,7 @@ import net.puffish.skillsmod.config.CategoryConfig;
 import net.puffish.skillsmod.config.GeneralConfig;
 import net.puffish.skillsmod.config.skill.SkillConfig;
 import net.puffish.skillsmod.config.skill.SkillDefinitionConfig;
+import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
 import net.puffish.skillsmod.util.PointSources;
 
 import java.util.HashMap;
@@ -97,9 +98,20 @@ public class CategoryData {
 		return nbt;
 	}
 
-	public Skill.State getSkillState(CategoryConfig category, SkillConfig skill, SkillDefinitionConfig definition) {
+        public Skill.State getSkillState(CategoryConfig category, SkillConfig skill, SkillDefinitionConfig definition) {
                var level = unlockedSkills.getOrDefault(skill.id(), 0);
-               if (level >= definition.maxLevels()) {
+               int maxLevels = definition.maxLevels();
+
+               for (var reward : definition.rewards()) {
+                       var inst = reward.instance();
+                       if (inst instanceof PerLevelRewardsReward plr) {
+                               if (plr.getSkillId() == null || plr.getSkillId().equals(skill.id())) {
+                                       maxLevels = Math.max(maxLevels, plr.getMaxLevel());
+                               }
+                       }
+               }
+
+               if (level >= maxLevels) {
                        return Skill.State.UNLOCKED;
                }
 
@@ -112,14 +124,14 @@ public class CategoryData {
 			return Skill.State.EXCLUDED;
 		}
 
-		if (category.connections()
-				.normal()
-				.getNeighborsFor(skill.id())
+                if (category.connections()
+                                .normal()
+                                .getNeighborsFor(skill.id())
                                .map(neighbors -> neighbors.stream().filter(unlockedSkills::containsKey).count())
-				.orElse(0L) >= definition.requiredSkills()
-		) {
-			return canAfford(category, definition) ? Skill.State.AFFORDABLE : Skill.State.AVAILABLE;
-		}
+                                .orElse(0L) >= definition.requiredSkills()
+                ) {
+                        return canAfford(category, skill, definition) ? Skill.State.AFFORDABLE : Skill.State.AVAILABLE;
+                }
 
 		if (skill.isRoot()) {
                        if (category.general().exclusiveRoot() && unlockedSkills.keySet().stream()
@@ -129,16 +141,26 @@ public class CategoryData {
 				return Skill.State.LOCKED;
 			}
 
-			return canAfford(category, definition) ? Skill.State.AFFORDABLE : Skill.State.AVAILABLE;
-		}
+                        return canAfford(category, skill, definition) ? Skill.State.AFFORDABLE : Skill.State.AVAILABLE;
+                }
 
 		return Skill.State.LOCKED;
 	}
 
-	private boolean canAfford(CategoryConfig category, SkillDefinitionConfig definition) {
-		return getPointsLeft(category) >= Math.max(definition.requiredPoints(), definition.cost())
-				&& getSpentPoints(category) >= definition.requiredSpentPoints();
-	}
+        private boolean canAfford(CategoryConfig category, SkillConfig skill, SkillDefinitionConfig definition) {
+                int cost = definition.cost();
+                for (var reward : definition.rewards()) {
+                        var inst = reward.instance();
+                        if (inst instanceof PerLevelRewardsReward plr) {
+                                if (plr.getSkillId() == null || plr.getSkillId().equals(skill.id())) {
+                                        cost = Math.max(cost, plr.getPointsPerLevel());
+                                }
+                        }
+                }
+
+                return getPointsLeft(category) >= Math.max(definition.requiredPoints(), cost)
+                                && getSpentPoints(category) >= definition.requiredSpentPoints();
+        }
 
 	public boolean canUnlockSkill(CategoryConfig category, SkillConfig skill, boolean force) {
 		var definitionId = skill.definitionId();

--- a/Common/src/test/java/net/puffish/skillsmod/server/data/CategoryDataTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/server/data/CategoryDataTest.java
@@ -1,0 +1,143 @@
+package net.puffish.skillsmod.server.data;
+
+import net.minecraft.advancement.AdvancementFrame;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.api.Skill;
+import net.puffish.skillsmod.common.BackgroundPosition;
+import net.puffish.skillsmod.config.BackgroundConfig;
+import net.puffish.skillsmod.config.CategoryConfig;
+import net.puffish.skillsmod.config.FrameConfig;
+import net.puffish.skillsmod.config.GeneralConfig;
+import net.puffish.skillsmod.config.IconConfig;
+import net.puffish.skillsmod.config.colors.ColorsConfig;
+import net.puffish.skillsmod.config.skill.SkillConfig;
+import net.puffish.skillsmod.config.skill.SkillDefinitionConfig;
+import net.puffish.skillsmod.config.skill.SkillDefinitionsConfig;
+import net.puffish.skillsmod.config.skill.SkillRewardConfig;
+import net.puffish.skillsmod.config.skill.SkillConnectionsConfig;
+import net.puffish.skillsmod.config.skill.SkillConnectionsGroupConfig;
+import net.puffish.skillsmod.config.skill.SkillsConfig;
+import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
+import net.puffish.skillsmod.util.PointSources;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class CategoryDataTest {
+    @Test
+    public void testPerLevelRewardExtendsMaxLevel() throws Exception {
+        Map<Integer, List<SkillRewardConfig>> levelRewards = new HashMap<>();
+        Constructor<PerLevelRewardsReward> ctor = PerLevelRewardsReward.class.getDeclaredConstructor(Map.class, String.class, int.class, int.class);
+        ctor.setAccessible(true);
+        PerLevelRewardsReward plr = ctor.newInstance(levelRewards, "skill", 3, 0);
+        SkillRewardConfig rewardConfig = new SkillRewardConfig(PerLevelRewardsReward.ID, plr);
+
+        SkillDefinitionConfig definition = new SkillDefinitionConfig(
+                "def",
+                Identifier.of("puffish_skills", "default"),
+                1,
+                List.of(),
+                List.of(),
+                Text.of("Test"),
+                new IconConfig.TextureIconConfig(Identifier.of("minecraft", "stone")),
+                new FrameConfig.AdvancementFrameConfig(AdvancementFrame.TASK),
+                1f,
+                false,
+                List.of(rewardConfig),
+                0,
+                0,
+                0,
+                0,
+                1
+        );
+
+        Constructor<SkillDefinitionsConfig> defsCtor = SkillDefinitionsConfig.class.getDeclaredConstructor(Map.class);
+        defsCtor.setAccessible(true);
+        SkillDefinitionsConfig definitions = defsCtor.newInstance(Map.of("def", definition));
+        SkillConfig skill = new SkillConfig("skill", 0, 0, "def", true);
+        SkillsConfig skills = new SkillsConfig(Map.of("skill", skill));
+        SkillConnectionsConfig connections = new SkillConnectionsConfig(SkillConnectionsGroupConfig.empty(), SkillConnectionsGroupConfig.empty());
+
+        GeneralConfig general = new GeneralConfig(
+                Text.of("Cat"),
+                new IconConfig.TextureIconConfig(Identifier.of("minecraft", "stone")),
+                new BackgroundConfig(Identifier.of("minecraft", "stone"), 16, 16, BackgroundPosition.NONE),
+                ColorsConfig.createDefault(),
+                true,
+                0,
+                false,
+                Integer.MAX_VALUE
+        );
+
+        CategoryConfig category = new CategoryConfig(new Identifier("test", "cat"), general, definitions, skills, connections, Optional.empty());
+        CategoryData data = CategoryData.create(general);
+
+        Assertions.assertEquals(Skill.State.AFFORDABLE, data.getSkillState(category, skill, definition));
+        data.unlockSkill("skill");
+        Assertions.assertEquals(Skill.State.AFFORDABLE, data.getSkillState(category, skill, definition));
+        data.unlockSkill("skill");
+        Assertions.assertEquals(Skill.State.AFFORDABLE, data.getSkillState(category, skill, definition));
+        data.unlockSkill("skill");
+        Assertions.assertEquals(Skill.State.UNLOCKED, data.getSkillState(category, skill, definition));
+    }
+
+    @Test
+    public void testPerLevelRewardCostsPointsPerLevel() throws Exception {
+        Map<Integer, List<SkillRewardConfig>> levelRewards = new HashMap<>();
+        Constructor<PerLevelRewardsReward> ctor = PerLevelRewardsReward.class.getDeclaredConstructor(Map.class, String.class, int.class, int.class);
+        ctor.setAccessible(true);
+        PerLevelRewardsReward plr = ctor.newInstance(levelRewards, "skill", 1, 2);
+        SkillRewardConfig rewardConfig = new SkillRewardConfig(PerLevelRewardsReward.ID, plr);
+
+        SkillDefinitionConfig definition = new SkillDefinitionConfig(
+                "def",
+                Identifier.of("puffish_skills", "default"),
+                1,
+                List.of(),
+                List.of(),
+                Text.of("Test"),
+                new IconConfig.TextureIconConfig(Identifier.of("minecraft", "stone")),
+                new FrameConfig.AdvancementFrameConfig(AdvancementFrame.TASK),
+                1f,
+                false,
+                List.of(rewardConfig),
+                0,
+                0,
+                0,
+                0,
+                1
+        );
+
+        Constructor<SkillDefinitionsConfig> defsCtor = SkillDefinitionsConfig.class.getDeclaredConstructor(Map.class);
+        defsCtor.setAccessible(true);
+        SkillDefinitionsConfig definitions = defsCtor.newInstance(Map.of("def", definition));
+        SkillConfig skill = new SkillConfig("skill", 0, 0, "def", true);
+        SkillsConfig skills = new SkillsConfig(Map.of("skill", skill));
+        SkillConnectionsConfig connections = new SkillConnectionsConfig(SkillConnectionsGroupConfig.empty(), SkillConnectionsGroupConfig.empty());
+
+        GeneralConfig general = new GeneralConfig(
+                Text.of("Cat"),
+                new IconConfig.TextureIconConfig(Identifier.of("minecraft", "stone")),
+                new BackgroundConfig(Identifier.of("minecraft", "stone"), 16, 16, BackgroundPosition.NONE),
+                ColorsConfig.createDefault(),
+                true,
+                0,
+                false,
+                Integer.MAX_VALUE
+        );
+
+        CategoryConfig category = new CategoryConfig(new Identifier("test", "cat"), general, definitions, skills, connections, Optional.empty());
+        CategoryData data = CategoryData.create(general);
+
+        Assertions.assertEquals(Skill.State.AVAILABLE, data.getSkillState(category, skill, definition));
+
+        data.setPoints(PointSources.STARTING, 2);
+        Assertions.assertEquals(Skill.State.AFFORDABLE, data.getSkillState(category, skill, definition));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,17 +18,14 @@ Skill definitions describe how a skill looks and what it grants. Datapacks may n
 
 - `title`, `icon`, `frame`, `size`, and `rewards` work as before.
 
-A basic skill definition might look like this:
+A basic skill definition using per-level rewards might look like this:
 
 ```json
 {
   "stacked_power": {
-      "type": "puffish_skills:stackable",
       "title": "Master Miner",
       "icon": { "type": "item", "data": { "item": "minecraft:diamond_pickaxe" } },
       "size": 1.0,
-      "required_points": 3,
-      "merge_description": false,
       "descriptions": [
           "Current: +1 melee damage",
           "Current: +10% mining speed",
@@ -43,8 +40,7 @@ A basic skill definition might look like this:
           {
               "type": "puffish_skills:per_level_rewards",
               "data": {
-
-                    "skill_id": "19aazycn9ii0lfh1", 
+                    "skill_id": "19aazycn9ii0lfh1",
                     "max_skill_level": 3,
                     "points_per_level": 1,
                     "levels": {
@@ -56,7 +52,7 @@ A basic skill definition might look like this:
                         ],
                         "2": [
                             {"type": "puffish_skills:command",
-                              "data": { "command": "give @p minecraft:experience_bottle 1" } 
+                              "data": { "command": "give @p minecraft:experience_bottle 1" }
                             }
                         ],
                         "3": [
@@ -67,10 +63,6 @@ A basic skill definition might look like this:
                         ]
                     }
                 }
-          },
-          { 
-              "type": "puffish_skills:command",
-              "data": { "command": "give @p minecraft:experience_bottle 1" }
           }
       ],
       "metadata": { "icon": "74sqblu8lgizj777" }
@@ -103,7 +95,7 @@ Each nested reward behaves as if it were a normal reward, but is only active whe
 The fields `skill_id`, `max_skill_level` and `points_per_level` are used only by
 `puffish_skills:per_level_rewards`. They define which skill is leveled, the
 highest level obtainable through the reward, and how many category points are
-spent per level.
+spent per level instead of the skill's `required_points` value.
 
 All active level rewards stack automatically, so unlocking additional levels increases the total bonus without any extra configuration. When a level is unlocked the category loses `points_per_level` points. A player cannot level beyond `max_skill_level` unless they have enough points to pay for the additional levels.
 


### PR DESCRIPTION
## Summary
- treat per-level reward `max_skill_level` as an effective cap for normal skills
- apply `points_per_level` as the skill cost when determining affordability
- add regression tests and document per-level reward usage

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_688d8493821883279abf8d9bf6654e2f