### PR TITLE
Clarify max skill level placement in stackable skill example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ This mod provides an API to create skill trees via datapacks. Categories and ski
 Skill definitions describe how a skill looks and what it grants. Datapacks may now define stackable skills with extra fields:
 
 - `type` – identifier of the skill type. Defaults to `puffish_skills:default`.
-- `max_skill_level` – how many times the skill can be unlocked. This value defines
-  the maximum level a skill can reach.
 - `descriptions` – list of tooltip lines shown for each level.
 - `extra_descriptions` – list of extra tooltip lines (displayed while holding Shift).
 - `merge_description` – when `true`, descriptions and extra descriptions accumulate from previous levels starting when level 2 is reached. The tooltip for the very first level is shown on its own. Defaults to `false` when omitted.
 - Tooltip lines automatically adjust based on how many times the skill has been unlocked. When hovering a skill, the
   entry matching the player's current level is shown, and holding Shift displays the line for the next level (or a final
   message if the skill is maxed).
+
+The number of times a skill can be unlocked is configured through the `max_skill_level` value inside the `puffish_skills:per_level_rewards` reward.
 
 - `title`, `icon`, `frame`, `size`, and `rewards` work as before.
 


### PR DESCRIPTION
## Summary
- clarify that `max_skill_level` is configured inside `puffish_skills:per_level_rewards`
- update README stackable skill example accordingly

## Testing
- `./gradlew test`
- `./gradlew check`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688da1d917c88327a666573a54707a5e