### PR TITLE
Infer skill max level from per-level rewards

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
@@ -15,6 +15,7 @@ import net.puffish.skillsmod.util.LegacyUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
 
 public record SkillDefinitionConfig(
 
@@ -53,21 +54,12 @@ public record SkillDefinitionConfig(
                                 .getSuccess();
 
 
-		var type = rootObject.get("type")
-				.getSuccess() // ignore failure because this property is optional
-				.flatMap(element -> BuiltinJson.parseIdentifier(element)
-						.ifFailure(problems::add)
-						.getSuccess())
-				.orElse(Identifier.of("puffish_skills", "default"));
-
-		var maxLevelsElement = rootObject.get("max_skill_level").getSuccess()
-                                .or(() -> rootObject.get("max_levels").getSuccess());
-
-                var maxLevels = maxLevelsElement
-                                .flatMap(element -> element.getAsInt()
+                var type = rootObject.get("type")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(element -> BuiltinJson.parseIdentifier(element)
                                                 .ifFailure(problems::add)
                                                 .getSuccess())
-                                .orElse(1);
+                                .orElse(Identifier.of("puffish_skills", "default"));
 
 		var descriptions = rootObject.getArray("descriptions")
 				.getSuccess() // ignore failure because this property is optional
@@ -127,12 +119,29 @@ public record SkillDefinitionConfig(
                                 )
                                 .orElse(false);
 
-		var rewards = rootObject.getArray("rewards")
-				.getSuccess() // ignore failure because this property is optional
-				.flatMap(array -> array.getAsList((i, element) -> SkillRewardConfig.parse(element, context)).mapFailure(Problem::combine)
-						.ifFailure(problems::add)
-						.getSuccess())
-				.orElseGet(List::of);
+                var rewards = rootObject.getArray("rewards")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(array -> array.getAsList((i, element) -> SkillRewardConfig.parse(element, context))
+                                                .mapFailure(Problem::combine)
+                                                .ifFailure(problems::add)
+                                                .getSuccess())
+                                .orElseGet(List::of);
+
+                var maxLevelsElement = rootObject.get("max_skill_level").getSuccess()
+                                .or(() -> rootObject.get("max_levels").getSuccess());
+
+                var maxLevels = maxLevelsElement
+                                .flatMap(element -> element.getAsInt()
+                                                .ifFailure(problems::add)
+                                                .getSuccess())
+                                .orElseGet(() -> rewards.stream()
+                                                .map(SkillRewardConfig::instance)
+                                                .filter(PerLevelRewardsReward.class::isInstance)
+                                                .map(PerLevelRewardsReward.class::cast)
+                                                .filter(reward -> reward.getSkillId() == null || reward.getSkillId().equals(id))
+                                                .mapToInt(PerLevelRewardsReward::getMaxLevel)
+                                                .max()
+                                                .orElse(1));
 
 		var cost = rootObject.get("cost")
 				.getSuccess() // ignore failure because this property is optional

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
@@ -86,6 +86,7 @@ public class PerLevelRewardsReward implements Reward {
                 }
             }
         });
+        int definedMaxLevel = levelRewards.keySet().stream().max(Integer::compareTo).orElse(0);
 
         // Access optional fields and validate values
         var optSkillId = rootObject.getString("skill_id")
@@ -106,7 +107,6 @@ public class PerLevelRewardsReward implements Reward {
                 problems.add(path.createProblem("Expected a value \u2265 1"));
             }
         });
-        int optMaxLevel = optMaxLevelTmp.orElse(Integer.MAX_VALUE);
 
         var optPointsPerLevelTmp = rootObject.get("points_per_level")
                 .getSuccess() // optional
@@ -124,7 +124,7 @@ public class PerLevelRewardsReward implements Reward {
         if (problems.isEmpty()) {
             return Result.success(new PerLevelRewardsReward(levelRewards,
                             optSkillId.orElse(null),
-                            optMaxLevel,
+                            optMaxLevelTmp.orElse(Math.max(1, definedMaxLevel)),
                             optPointsPerLevel));
         } else {
             return Result.failure(Problem.combine(problems));

--- a/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
@@ -1,0 +1,53 @@
+package net.puffish.skillsmod.config.skill;
+
+import net.minecraft.server.MinecraftServer;
+import net.puffish.skillsmod.api.config.ConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonPath;
+import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SkillDefinitionConfigTest {
+    private static class DummyContext implements ConfigContext {
+        @Override
+        public MinecraftServer getServer() {
+            return null;
+        }
+
+        @Override
+        public void emitWarning(String message) {
+            // ignore
+        }
+    }
+
+    static {
+        try {
+            PerLevelRewardsReward.register();
+        } catch (IllegalStateException ignored) {
+        }
+    }
+
+    @Test
+    public void testMaxLevelFromPerLevelReward() {
+        String json = """
+{
+  \"title\": \"Test\",
+  \"icon\": { \"type\": \"texture\", \"data\": { \"texture\": \"minecraft:stone\" } },
+  \"rewards\": [
+    {
+      \"type\": \"puffish_skills:per_level_rewards\",
+      \"data\": {
+        \"skill_id\": \"skill\",
+        \"points_per_level\": 0,
+        \"levels\": { \"1\": [], \"2\": [], \"3\": [] }
+      }
+    }
+  ]
+}
+""";
+        var element = JsonElement.parseString(json, JsonPath.create("test")).getSuccess().orElseThrow();
+        var result = SkillDefinitionConfig.parse("skill", element, new DummyContext());
+        Assertions.assertEquals(3, result.getSuccess().orElseThrow().maxLevels());
+    }
+}

--- a/Common/src/test/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsRewardTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsRewardTest.java
@@ -40,13 +40,19 @@ public class PerLevelRewardsRewardTest {
 	    return PerLevelRewardsReward.parse(new DummyContext(element));
 	}
 
-	@Test
-	public void testValidValues() {
+        @Test
+        public void testValidValues() {
             String json = "{\"skill_id\":\"s\",\"max_skill_level\":1,\"points_per_level\":0,\"levels\":{\"1\":[]}}";
-	    var result = parse(json);
-	    Assertions.assertTrue(result.getSuccess().isPresent(),
-	            result.getFailure().map(Object::toString).orElse("Unexpected failure"));
-	}
+            var result = parse(json);
+            Assertions.assertEquals(1, result.getSuccess().orElseThrow().getMaxLevel());
+        }
+
+        @Test
+        public void testLevelsInferMaxLevel() {
+            String json = "{\"skill_id\":\"s\",\"points_per_level\":0,\"levels\":{\"1\":[],\"2\":[]}}";
+            var result = parse(json);
+            Assertions.assertEquals(2, result.getSuccess().orElseThrow().getMaxLevel());
+        }
 
 	@Test
 	public void testInvalidMaxLevel() {

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This mod provides an API to create skill trees via datapacks. Categories and ski
 Skill definitions describe how a skill looks and what it grants. Datapacks may now define stackable skills with extra fields:
 
 - `type` – identifier of the skill type. Defaults to `puffish_skills:default`.
-- `max_skill_level` – how many times the skill can be unlocked. This value defines
-  the maximum level a skill can reach.
+ - `max_skill_level` – how many times the skill can be unlocked. This value defines
+   the maximum level a skill can reach. When omitted and the skill uses
+   `puffish_skills:per_level_rewards`, the highest level is inferred from that reward.
 - `descriptions` – list of tooltip lines shown for each level.
 - `extra_descriptions` – list of extra tooltip lines (displayed while holding Shift).
 - `merge_description` – when `true`, descriptions and extra descriptions accumulate from previous levels starting when level 2 is reached. The tooltip for the very first level is shown on its own. Defaults to `false` when omitted.
@@ -95,7 +96,9 @@ Each nested reward behaves as if it were a normal reward, but is only active whe
 The fields `skill_id`, `max_skill_level` and `points_per_level` are used only by
 `puffish_skills:per_level_rewards`. They define which skill is leveled, the
 highest level obtainable through the reward, and how many category points are
-spent per level instead of the skill's `required_points` value.
+spent per level instead of the skill's `required_points` value. If the skill
+definition omits `max_skill_level`, this field also determines the skill's
+maximum level.
 
 All active level rewards stack automatically, so unlocking additional levels increases the total bonus without any extra configuration. When a level is unlocked the category loses `points_per_level` points. A player cannot level beyond `max_skill_level` unless they have enough points to pay for the additional levels.
 


### PR DESCRIPTION
## Summary
- derive a skill's maximum level from its `per_level_rewards` when `max_skill_level` isn't specified
- default `per_level_rewards`' max level to the highest defined level
- document and test inferred level behaviour

## Testing
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_688e11f1d96c8327aa9215b660a48f4c