### PR TITLE
Add count and all options to refund command

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
+++ b/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
@@ -3,6 +3,7 @@ package net.puffish.skillsmod.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
@@ -45,6 +46,12 @@ public class SkillsCommand {
                                                                 .then(CommandManager.argument("category", CategoryArgumentType.category())
                                                                                 .then(CommandManager.argument("skill", SkillArgumentType.skillFromCategory("category"))
                                                                                                 .executes(SkillsCommand::refund)
+                                                                                                .then(CommandManager.argument("count", IntegerArgumentType.integer(1))
+                                                                                                                .executes(SkillsCommand::refundCount)
+                                                                                                )
+                                                                                                .then(CommandManager.literal("all")
+                                                                                                                .executes(SkillsCommand::refundAll)
+                                                                                                )
                                                                                 )
                                                                 )
                                                 )
@@ -104,30 +111,87 @@ public class SkillsCommand {
         }
 
        private static int refund(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+               return refund(context, 1);
+       }
+
+       private static int refund(CommandContext<ServerCommandSource> context, int count) throws CommandSyntaxException {
                var players = EntityArgumentType.getPlayers(context, "players");
                var category = CategoryArgumentType.getCategory(context, "category");
                var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
 
                var refunded = false;
                for (var player : players) {
-                       refunded |= SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId());
+                       for (var i = 0; i < count; i++) {
+                               if (!SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId())) {
+                                       break;
+                               }
+                               refunded = true;
+                       }
+               }
+
+               if (refunded) {
+                       if (count == 1) {
+                               CommandUtils.sendSuccess(
+                                               context,
+                                               players,
+                                               "skills.refund",
+                                               skill.getId(),
+                                               category.getId()
+                               );
+                       } else {
+                               CommandUtils.sendSuccess(
+                                               context,
+                                               players,
+                                               "skills.refund_many",
+                                               count,
+                                               skill.getId(),
+                                               category.getId()
+                               );
+                       }
+                       return players.size();
+               } else {
+                       context.getSource().sendError(SkillsMod.createTranslatable(
+                                       "command",
+                                       "skills.refund.no_levels",
+                                       skill.getId(),
+                                       category.getId()
+                       ));
+                       return 0;
+               }
+       }
+
+       private static int refundCount(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+               var count = IntegerArgumentType.getInteger(context, "count");
+               return refund(context, count);
+       }
+
+       private static int refundAll(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+               var players = EntityArgumentType.getPlayers(context, "players");
+               var category = CategoryArgumentType.getCategory(context, "category");
+               var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
+
+               var refunded = false;
+               for (var player : players) {
+                       while (SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId())) {
+                               refunded = true;
+                       }
                }
 
                if (refunded) {
                        CommandUtils.sendSuccess(
                                        context,
                                        players,
-                                       "skills.refund",
-                                       category.getId(),
-                                       skill.getId()
+                                       "skills.refund_all",
+                                       skill.getId(),
+                                       category.getId()
                        );
                        return players.size();
                } else {
                        context.getSource().sendError(SkillsMod.createTranslatable(
                                        "command",
                                        "skills.refund.no_levels",
-                                       category.getId(),
-                                       skill.getId()
+                                       skill.getId(),
+                                       category.getId()
                        ));
                        return 0;
                }

--- a/Common/src/main/resources/assets/puffish_skills/lang/en_us.json
+++ b/Common/src/main/resources/assets/puffish_skills/lang/en_us.json
@@ -56,6 +56,8 @@
 
         "command.puffish_skills.skills.refund.success.single": "Refunded one level of %s skill in category %s for %s",
         "command.puffish_skills.skills.refund.success.multiple": "Refunded one level of %s skill in category %s for %s players",
+        "command.puffish_skills.skills.refund_many.success.single": "Refunded %s levels of %s skill in category %s for %s",
+        "command.puffish_skills.skills.refund_many.success.multiple": "Refunded %s levels of %s skill in category %s for %s players",
         "command.puffish_skills.skills.refund_all.success.single": "Refunded all levels of %s skill in category %s for %s",
         "command.puffish_skills.skills.refund_all.success.multiple": "Refunded all levels of %s skill in category %s for %s players",
         "command.puffish_skills.skills.refund.no_levels": "None of the selected players had any levels of %s skill in category %s to refund.",

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ The `example-skill-level-template.zip` file contains a datapack demonstrating a 
 Administrators can refund skill levels using `/puffish_skills skills refund`.
 
 ```
-/puffish_skills skills refund <players> <category> <skill>
+/puffish_skills skills refund <players> <category> <skill> [<count>|all]
 ```
 
-This command refunds a single level of the chosen skill. It can be repeated as needed and reports an error if none of the selected players have any levels to refund.
+By default this command refunds one level of the chosen skill. Optionally provide a number of levels to refund or use `all` to remove every level. It reports an error if none of the selected players have any levels to refund.
 
 Refunding removes the reward linked to that level without running any unlock or lock triggers.


### PR DESCRIPTION
## Summary
- allow specifying a count or `all` when refunding skill levels
- add translations for multi-level refunds and document command usage

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_688e1cf429ac8327a838eeb27514dd7d