### PR TITLE
Use per-level reward max level

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
@@ -127,21 +127,34 @@ public record SkillDefinitionConfig(
                                                 .getSuccess())
                                 .orElseGet(List::of);
 
-                var maxLevelsElement = rootObject.get("max_skill_level").getSuccess()
-                                .or(() -> rootObject.get("max_levels").getSuccess());
+               var maxLevelsElement = rootObject.get("max_skill_level").getSuccess()
+                               .or(() -> rootObject.get("max_levels").getSuccess());
 
-                var maxLevels = maxLevelsElement
-                                .flatMap(element -> element.getAsInt()
-                                                .ifFailure(problems::add)
-                                                .getSuccess())
-                                .orElseGet(() -> rewards.stream()
-                                                .map(SkillRewardConfig::instance)
-                                                .filter(PerLevelRewardsReward.class::isInstance)
-                                                .map(PerLevelRewardsReward.class::cast)
-                                                .filter(reward -> reward.getSkillId() == null || reward.getSkillId().equals(id))
-                                                .mapToInt(PerLevelRewardsReward::getMaxLevel)
-                                                .max()
-                                                .orElse(1));
+               var optMaxLevels = maxLevelsElement
+                               .flatMap(element -> element.getAsInt()
+                                               .ifFailure(problems::add)
+                                               .getSuccess());
+
+               optMaxLevels.ifPresent(maxLevel -> {
+                       if (maxLevel < 1) {
+                               var path = rootObject.getPath().getObject(
+                                               rootObject.getJson().has("max_skill_level")
+                                                               ? "max_skill_level"
+                                                               : "max_levels");
+                               problems.add(path.createProblem("Expected a value \u2265 1"));
+                       }
+               });
+
+               int rewardMaxLevel = rewards.stream()
+                               .map(SkillRewardConfig::instance)
+                               .filter(PerLevelRewardsReward.class::isInstance)
+                               .map(PerLevelRewardsReward.class::cast)
+                               .filter(reward -> reward.getSkillId() == null || reward.getSkillId().equals(id))
+                               .mapToInt(PerLevelRewardsReward::getMaxLevel)
+                               .max()
+                               .orElse(1);
+
+               var maxLevels = Math.max(optMaxLevels.orElse(0), rewardMaxLevel);
 
 		var cost = rootObject.get("cost")
 				.getSuccess() // ignore failure because this property is optional

--- a/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
@@ -50,4 +50,29 @@ public class SkillDefinitionConfigTest {
         var result = SkillDefinitionConfig.parse("skill", element, new DummyContext());
         Assertions.assertEquals(3, result.getSuccess().orElseThrow().maxLevels());
     }
+
+    @Test
+    public void testMaxLevelOverridesRoot() {
+        String json = """
+{
+  \"title\": \"Test\",
+  \"icon\": { \"type\": \"texture\", \"data\": { \"texture\": \"minecraft:stone\" } },
+  \"max_skill_level\": 1,
+  \"rewards\": [
+    {
+      \"type\": \"puffish_skills:per_level_rewards\",
+      \"data\": {
+        \"skill_id\": \"skill\",
+        \"max_skill_level\": 3,
+        \"points_per_level\": 0,
+        \"levels\": { \"1\": [], \"2\": [], \"3\": [] }
+      }
+    }
+  ]
+}
+""";
+        var element = JsonElement.parseString(json, JsonPath.create("test")).getSuccess().orElseThrow();
+        var result = SkillDefinitionConfig.parse("skill", element, new DummyContext());
+        Assertions.assertEquals(3, result.getSuccess().orElseThrow().maxLevels());
+    }
 }


### PR DESCRIPTION
## Summary
- honor `max_skill_level` from per-level rewards when determining a skill's max levels
- cover root override behavior in `SkillDefinitionConfigTest`

## Testing
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688e24da849c8327a923b58673b7f1ad