### PR TITLE
Use max_skill_level exclusively in per-level rewards parser

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
@@ -93,18 +93,15 @@ public class PerLevelRewardsReward implements Reward {
                 .ifFailure(problems::add)
                 .getSuccess();
 
-        var maxLevelElement = rootObject.get("max_skill_level").getSuccess()
-                .or(() -> rootObject.get("max_level").getSuccess());
-
-        var optMaxLevelTmp = maxLevelElement.flatMap(element -> element.getAsInt()
-                .ifFailure(problems::add)
-                .getSuccess());
+        var optMaxLevelTmp = rootObject.get("max_skill_level")
+                .getSuccess()
+                .flatMap(element -> element.getAsInt()
+                        .ifFailure(problems::add)
+                        .getSuccess());
         optMaxLevelTmp.ifPresent(maxLevel -> {
             if (maxLevel < 1) {
-                var path = rootObject.getPath().getObject(
-                        rootObject.getJson().has("max_skill_level")
-                                ? "max_skill_level" : "max_level");
-                problems.add(path.createProblem("Expected a value \u2265 1"));
+                problems.add(rootObject.getPath().getObject("max_skill_level")
+                        .createProblem("Expected a value \u2265 1"));
             }
         });
 


### PR DESCRIPTION
## Summary
- remove legacy `max_level` handling in `PerLevelRewardsReward`
- validate `max_skill_level` directly

## Testing
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_688e362da3688327a4da83e5ebcaa92e