### PR TITLE
Clarify per-level reward configuration

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
@@ -119,12 +119,40 @@ public record SkillDefinitionConfig(
                                 )
                                 .orElse(false);
 
+                var optPointsPerLevelTmp = rootObject.get("points_per_level")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(element -> element.getAsInt()
+                                                .ifFailure(problems::add)
+                                                .getSuccess());
+                optPointsPerLevelTmp.ifPresent(points -> {
+                        if (points < 0) {
+                                problems.add(rootObject.getPath().getObject("points_per_level")
+                                                .createProblem("Expected a value \u2265 0"));
+                        }
+                });
+                int pointsPerLevel = optPointsPerLevelTmp.orElse(0);
+
                 var rewards = rootObject.getArray("rewards")
                                 .getSuccess() // ignore failure because this property is optional
-                                .flatMap(array -> array.getAsList((i, element) -> SkillRewardConfig.parse(element, context))
-                                                .mapFailure(Problem::combine)
-                                                .ifFailure(problems::add)
-                                                .getSuccess())
+                                .flatMap(array -> {
+                                        for (com.google.gson.JsonElement rewardElement : array.getJson()) {
+                                                if (rewardElement.isJsonObject()) {
+                                                        var obj = rewardElement.getAsJsonObject();
+                                                        var typeElement = obj.get("type");
+                                                        if (typeElement != null && typeElement.isJsonPrimitive()
+                                                                        && typeElement.getAsString().equals("puffish_skills:per_level_rewards")) {
+                                                                var data = obj.getAsJsonObject("data");
+                                                                if (data != null && !data.has("points_per_level")) {
+                                                                        data.addProperty("points_per_level", pointsPerLevel);
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                        return array.getAsList((i, element) -> SkillRewardConfig.parse(element, context))
+                                                        .mapFailure(Problem::combine)
+                                                        .ifFailure(problems::add)
+                                                        .getSuccess();
+                                })
                                 .orElseGet(List::of);
 
                var maxLevelsElement = rootObject.get("max_skill_level").getSuccess()

--- a/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
@@ -34,12 +34,12 @@ public class SkillDefinitionConfigTest {
 {
   \"title\": \"Test\",
   \"icon\": { \"type\": \"texture\", \"data\": { \"texture\": \"minecraft:stone\" } },
+  \"points_per_level\": 0,
   \"rewards\": [
     {
       \"type\": \"puffish_skills:per_level_rewards\",
       \"data\": {
         \"skill_id\": \"skill\",
-        \"points_per_level\": 0,
         \"levels\": { \"1\": [], \"2\": [], \"3\": [] }
       }
     }
@@ -57,6 +57,7 @@ public class SkillDefinitionConfigTest {
 {
   \"title\": \"Test\",
   \"icon\": { \"type\": \"texture\", \"data\": { \"texture\": \"minecraft:stone\" } },
+  \"points_per_level\": 0,
   \"max_skill_level\": 1,
   \"rewards\": [
     {
@@ -64,7 +65,6 @@ public class SkillDefinitionConfigTest {
       \"data\": {
         \"skill_id\": \"skill\",
         \"max_skill_level\": 3,
-        \"points_per_level\": 0,
         \"levels\": { \"1\": [], \"2\": [], \"3\": [] }
       }
     }

--- a/Common/src/test/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsRewardTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsRewardTest.java
@@ -49,9 +49,11 @@ public class PerLevelRewardsRewardTest {
 
         @Test
         public void testLevelsInferMaxLevel() {
-            String json = "{\"skill_id\":\"s\",\"points_per_level\":0,\"levels\":{\"1\":[],\"2\":[]}}";
+            String json = "{\"skill_id\":\"s\",\"levels\":{\"1\":[],\"2\":[]}}";
             var result = parse(json);
-            Assertions.assertEquals(2, result.getSuccess().orElseThrow().getMaxLevel());
+            var reward = result.getSuccess().orElseThrow();
+            Assertions.assertEquals(2, reward.getMaxLevel());
+            Assertions.assertEquals(0, reward.getPointsPerLevel());
         }
 
 	@Test

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Supported root fields:
 - `frame` – frame style for the icon.
 - `size` – size of the icon.
 - `max_skill_level` / `max_levels` – how many times the skill can be unlocked. This value defines the maximum level a skill can reach. When omitted and the skill uses `puffish_skills:per_level_rewards`, the highest level is inferred from that reward.
+- `points_per_level` – category points consumed for each level when using `puffish_skills:per_level_rewards`.
 - `descriptions` – list of tooltip lines shown for each level.
 - `extra_descriptions` – list of extra tooltip lines (displayed while holding Shift).
 - `merge_description` – when `true`, descriptions and extra descriptions accumulate from previous levels starting when level 2 is reached. The tooltip for the very first level is shown on its own. Defaults to `false` when omitted.
@@ -35,7 +36,8 @@ A basic skill definition using per-level rewards might look like this:
       "title": "Master Miner",
       "icon": { "type": "item", "data": { "item": "minecraft:diamond_pickaxe" } },
       "size": 1.0,
-      "max_levels": 3,
+      "max_skill_level": 3,
+      "points_per_level": 1,
       "merge_description": false,
       "descriptions": [
           "Current: +1 melee damage",
@@ -52,8 +54,6 @@ A basic skill definition using per-level rewards might look like this:
               "type": "puffish_skills:per_level_rewards",
               "data": {
                     "skill_id": "19aazycn9ii0lfh1",
-                    "max_skill_level": 3,
-                    "points_per_level": 1,
                     "levels": {
                         "1": [
                             { "type": "puffish_skills:attribute",
@@ -90,7 +90,8 @@ Use the `puffish_skills:stackable` skill type when you want to combine standard 
       "title": "Master Miner",
       "icon": { "type": "item", "data": { "item": "minecraft:diamond_pickaxe" } },
       "size": 1.0,
-      "max_levels": 3,
+      "max_skill_level": 3,
+      "points_per_level": 1,
       "required_points": 3,
       "merge_description": false,
       "descriptions": [
@@ -107,10 +108,7 @@ Use the `puffish_skills:stackable` skill type when you want to combine standard 
           {
               "type": "puffish_skills:per_level_rewards",
               "data": {
-
-                    "skill_id": "19aazycn9ii0lfh1", 
-                    "max_skill_level": 3,
-                    "points_per_level": 1,
+                    "skill_id": "19aazycn9ii0lfh1",
                     "levels": {
                         "1": [
                             { "type": "puffish_skills:attribute",
@@ -149,8 +147,6 @@ The reward registry includes `puffish_skills:per_level_rewards` which lets you s
 Supported fields:
 
 - `skill_id` – ID of the skill being leveled.
-- `max_skill_level` – highest level obtainable through the reward.
-- `points_per_level` – category points consumed for each level.
 - `levels` – maps level numbers to arrays of nested rewards.
 
 ```json
@@ -158,8 +154,6 @@ Supported fields:
   "type": "puffish_skills:per_level_rewards", // Skill levels can provide different rewards.
   "data": {
     "skill_id": "19aazycn9ii0lfh1",
-    "max_skill_level": 3,
-    "points_per_level": 1,
     "levels": {
       "1": [ { "type": "puffish_skills:attribute", "data": { "attribute": "generic.attack_damage", "value": 1, "operation": "addition" } } ],
       "2": [ { "type": "puffish_skills:command", "data": {"command": "give @p minecraft:experience_bottle 1"} } ],
@@ -171,7 +165,7 @@ Supported fields:
 
 Each nested reward behaves as if it were a normal reward, but is only active when the player's skill level is at least the specified level.
 
-The fields `skill_id`, `max_skill_level` and `points_per_level` are used only by `puffish_skills:per_level_rewards`. They define which skill is leveled, the highest level obtainable through the reward, and how many category points are spent per level instead of the skill's `required_points` value. If the skill definition omits `max_levels`/`max_skill_level`, this field also determines the skill's maximum level.
+The `skill_id` field is used only by `puffish_skills:per_level_rewards` to specify which skill is leveled. The skill's `max_skill_level` and `points_per_level` are defined in the root skill definition. If the skill omits `max_levels`/`max_skill_level`, the highest level is inferred from the reward's `levels`.
 
 All active level rewards stack automatically, so unlocking additional levels increases the total bonus without any extra configuration. When a level is unlocked the category loses `points_per_level` points. A player cannot level beyond `max_skill_level` unless they have enough points to pay for the additional levels.
 


### PR DESCRIPTION
## Summary
- Document `points_per_level` as a root skill field and illustrate `max_skill_level` remaining at the root.
- Inject root `points_per_level` into `per_level_rewards` to simplify configs.
- Update examples and explanations for both standard and stackable skills.

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688e4e1d40b08327b7390d0e7532e8d0