### PR TITLE
Convert to Forge addon with external puffish_skills dependency

### DIFF
--- a/Forge/build.gradle.kts
+++ b/Forge/build.gradle.kts
@@ -7,20 +7,23 @@ base.archivesName.set("${project.properties["archives_base_name"]}")
 version = "${project.properties["mod_version"]}-${project.properties["minecraft_version"]}-forge"
 group = "${project.properties["maven_group"]}"
 
-evaluationDependsOn(":Common")
-
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+}
+
+repositories {
+        mavenLocal()
+        mavenCentral()
 }
 
 dependencies {
 	minecraft("com.mojang:minecraft:${project.properties["minecraft_version"]}")
 	mappings("net.fabricmc:yarn:${project.properties["yarn_mappings"]}:v2")
 
-	forge("net.minecraftforge:forge:${project.properties["minecraft_version"]}-${project.properties["forge_version"]}")
+        forge("net.minecraftforge:forge:${project.properties["minecraft_version"]}-${project.properties["forge_version"]}")
 
-	implementation(project(path = ":Common", configuration = "namedElements"))
+        implementation("net.puffish.skillsmod:puffish_skills:${project.properties["puffish_skills_dependency_version"]}")
 }
 
 loom {
@@ -28,28 +31,14 @@ loom {
 	forge.mixinConfig("puffish_skills.mixins.json")
 }
 
-tasks.test {
-	dependsOn(project(":Common").tasks.test)
-}
-
-tasks.check {
-	dependsOn(project(":Common").tasks.check)
-}
-
 tasks.jar {
-	from(project.rootDir.resolve("LICENSE.txt"))
-	from(project.rootDir.resolve("LICENSE-RESOURCES.txt"))
+        from(project.rootDir.resolve("LICENSE.txt"))
+        from(project.rootDir.resolve("LICENSE-RESOURCES.txt"))
 }
 
 tasks.processResources {
-	from(project(":Common").sourceSets.main.get().resources)
-
-	inputs.property("version", project.properties["mod_version"])
-	filesMatching("META-INF/mods.toml") {
-		expand(mapOf("version" to project.properties["mod_version"]))
-	}
-}
-
-tasks.compileJava {
-	source(project(":Common").sourceSets.main.get().java)
+        inputs.property("version", project.properties["mod_version"])
+        filesMatching("META-INF/mods.toml") {
+                expand(mapOf("version" to project.properties["mod_version"], "puffish_skills_dependency_version" to project.properties["puffish_skills_dependency_version"]))
+        }
 }

--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -3,22 +3,29 @@ loaderVersion="[46,)"
 license="All Rights Reserved"
 
 [[mods]]
-modId="puffish_skills"
+modId="puffish_skills_leveling"
 version="${version}"
-displayName="Pufferfish's Skills"
+displayName="Pufferfish's Skills Leveling"
 authors="Pufferfish"
-description="Adds a fully configurable skill system to the game."
+description="Adds leveling support as an addon for Pufferfish's Skills."
 
-[[dependencies.puffish_skills]]
+[[dependencies.puffish_skills_leveling]]
 modId="forge"
 mandatory=true
 versionRange="[46,)"
 ordering="NONE"
 side="BOTH"
 
-[[dependencies.puffish_skills]]
+[[dependencies.puffish_skills_leveling]]
 modId="minecraft"
 mandatory=true
 versionRange="[1.20,1.21)"
+ordering="NONE"
+side="BOTH"
+
+[[dependencies.puffish_skills_leveling]]
+modId="puffish_skills"
+mandatory=true
+versionRange="[${puffish_skills_dependency_version},)"
 ordering="NONE"
 side="BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ archives_base_name = puffish_skills
 mixin_version = 0.12.4+mixin.0.8.5
 junit_version = 5.7.1
 fabric_loader_version=0.14.21
+puffish_skills_dependency_version=0.16.3

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,4 +14,4 @@ plugins {
 
 rootProject.name = "Pufferfish's Skills"
 
-include("Common", "Fabric", "Forge")
+include("Forge")


### PR DESCRIPTION
## Summary
- Configure Forge module to build as an addon depending on `puffish_skills`
- Strip cross-platform modules and update settings to include only Forge
- Update mod metadata and gradle properties for addon setup

## Testing
- `./gradlew build` *(fails: Could not find net.puffish.skillsmod:puffish_skills:0.16.3)*

------
https://chatgpt.com/codex/tasks/task_e_688e59efeb8c8327b300e652db84e17f