### PR TITLE
Specify SkillsMod dependency version

### DIFF
--- a/Forge/build.gradle.kts
+++ b/Forge/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
         forge("net.minecraftforge:forge:${project.properties["minecraft_version"]}-${project.properties["forge_version"]}")
 
-        modImplementation("net.puffish.skillsmod:puffish_skills:${project.properties["puffish_skills_dependency_version"]}")
+        implementation("net.puffish:skillsmod:${project.properties["puffish_skills_dependency_version"]}:forge@jar")
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ archives_base_name = puffish_skills
 mixin_version = 0.12.4+mixin.0.8.5
 junit_version = 5.7.1
 fabric_loader_version=0.14.21
-puffish_skills_dependency_version=0.16.3
+puffish_skills_dependency_version=0.16.4-1.20


### PR DESCRIPTION
## Summary
- Use Forge jar of SkillsMod via an explicit dependency version
- Track SkillsMod 0.16.4-1.20 in gradle properties

## Testing
- `./gradlew build` *(fails: Could not find net.puffish:skillsmod:0.16.4-1.20)*
- `./gradlew test` *(fails: Could not find net.puffish:skillsmod:0.16.4-1.20)*
- `./gradlew check` *(fails: Could not find net.puffish:skillsmod:0.16.4-1.20)*

------
https://chatgpt.com/codex/tasks/task_e_688e9361ceec8327bcd8b392bb61290e