### PR TITLE
Update Forge networking for Minecraft 1.20.1

### DIFF
--- a/Forge/gradle.properties
+++ b/Forge/gradle.properties
@@ -1,4 +1,4 @@
 loom.platform=forge
 
 # Dependencies
-forge_version=46.0.14
+forge_version=47.0.3

--- a/Forge/src/main/java/net/puffish/skillsmod/main/ForgeClientMain.java
+++ b/Forge/src/main/java/net/puffish/skillsmod/main/ForgeClientMain.java
@@ -1,11 +1,11 @@
 package net.puffish.skillsmod.main;
 
 import io.netty.buffer.Unpooled;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.network.PacketByteBuf;
-import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -51,20 +51,20 @@ public class ForgeClientMain {
 		}
 	}
 
-	private void onInputKey(InputEvent.Key event) {
-		for (var keyBinding : keyBindings) {
-			if (keyBinding.keyBinding.wasPressed()) {
-				keyBinding.handler.handle();
-			}
-		}
-	}
+        private void onInputKey(InputEvent.Key event) {
+                for (var keyBinding : keyBindings) {
+                        if (keyBinding.keyBinding.consumeClick()) {
+                                keyBinding.handler.handle();
+                        }
+                }
+        }
 
-	private record KeyBindingWithHandler(KeyBinding keyBinding, KeyBindingHandler handler) {
-	}
+        private record KeyBindingWithHandler(KeyMapping keyBinding, KeyBindingHandler handler) {
+        }
 
 	private static class ClientRegistrarImpl implements ClientRegistrar {
 		@Override
-		public <T extends InPacket> void registerInPacket(Identifier identifier, Function<PacketByteBuf, T> reader, ClientPacketHandler<T> handler) {
+                public <T extends InPacket> void registerInPacket(ResourceLocation identifier, Function<FriendlyByteBuf, T> reader, ClientPacketHandler<T> handler) {
 			var channel = NetworkRegistry.newEventChannel(
 					identifier,
 					() -> "1",
@@ -85,7 +85,7 @@ public class ForgeClientMain {
 		}
 
 		@Override
-		public void registerOutPacket(Identifier id) { }
+                public void registerOutPacket(ResourceLocation id) { }
 	}
 
 	private class ClientEventReceiverImpl implements ClientEventReceiver {
@@ -97,20 +97,20 @@ public class ForgeClientMain {
 
 	private class KeyBindingReceiverImpl implements KeyBindingReceiver {
 		@Override
-		public void registerKeyBinding(KeyBinding keyBinding, KeyBindingHandler handler) {
-			keyBindings.add(new KeyBindingWithHandler(keyBinding, handler));
-			var options = MinecraftClient.getInstance().options;
-			options.allKeys = ArrayUtils.add(options.allKeys, keyBinding);
-		}
-	}
+                public void registerKeyBinding(KeyMapping keyBinding, KeyBindingHandler handler) {
+                        keyBindings.add(new KeyBindingWithHandler(keyBinding, handler));
+                        var options = Minecraft.getInstance().options;
+                        options.keyMappings = ArrayUtils.add(options.keyMappings, keyBinding);
+                }
+        }
 
-	private static class ClientPacketSenderImpl implements ClientPacketSender {
-		@Override
-		public void send(OutPacket packet) {
-			var buf = new PacketByteBuf(Unpooled.buffer());
-			packet.write(buf);
-			Objects.requireNonNull(MinecraftClient.getInstance().getNetworkHandler())
-					.sendPacket(new CustomPayloadC2SPacket(packet.getId(), buf));
-		}
-	}
+        private static class ClientPacketSenderImpl implements ClientPacketSender {
+                @Override
+                public void send(OutPacket packet) {
+                        var buf = new FriendlyByteBuf(Unpooled.buffer());
+                        packet.write(buf);
+                        Objects.requireNonNull(Minecraft.getInstance().getConnection())
+                                        .send(new ServerboundCustomPayloadPacket(packet.getId(), buf));
+                }
+        }
 }

--- a/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
+++ b/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
@@ -4,12 +4,12 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import io.netty.buffer.Unpooled;
 import net.minecraft.command.argument.ArgumentTypes;
 import net.minecraft.command.argument.serialize.ArgumentSerializer;
-import net.minecraft.network.PacketByteBuf;
-import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKeys;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.GameRules;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
@@ -65,21 +65,21 @@ public class ForgeMain {
 		);
 	}
 
-	private void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
-		if (event.getEntity() instanceof ServerPlayerEntity serverPlayer) {
-			for (var listener : serverListeners) {
-				listener.onPlayerJoin(serverPlayer);
-			}
-		}
-	}
+        private void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+                if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+                        for (var listener : serverListeners) {
+                                listener.onPlayerJoin(serverPlayer);
+                        }
+                }
+        }
 
-	private void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
-		if (event.getEntity() instanceof ServerPlayerEntity serverPlayer) {
-			for (var listener : serverListeners) {
-				listener.onPlayerLeave(serverPlayer);
-			}
-		}
-	}
+        private void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+                if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+                        for (var listener : serverListeners) {
+                                listener.onPlayerLeave(serverPlayer);
+                        }
+                }
+        }
 
 	private void onServerStarting(ServerStartingEvent event) {
 		var server = event.getServer();
@@ -110,11 +110,11 @@ public class ForgeMain {
 
 	private static class ServerRegistrarImpl implements ServerRegistrar {
 		@Override
-		public <V, T extends V> void register(Registry<V> registry, Identifier id, T entry) {
-			var deferredRegister = DeferredRegister.create(registry.getKey(), id.getNamespace());
-			deferredRegister.register(id.getPath(), () -> entry);
-			deferredRegister.register(FMLJavaModLoadingContext.get().getModEventBus());
-		}
+                public <V, T extends V> void register(Registry<V> registry, ResourceLocation id, T entry) {
+                        var deferredRegister = DeferredRegister.create(registry.getKey(), id.getNamespace());
+                        deferredRegister.register(id.getPath(), () -> entry);
+                        deferredRegister.register(FMLJavaModLoadingContext.get().getModEventBus());
+                }
 
 		@Override
 		public <T extends GameRules.Rule<T>> void registerGameRule(GameRules.Key<T> key, GameRules.Type<T> type) {
@@ -122,20 +122,20 @@ public class ForgeMain {
 		}
 
 		@Override
-		public <A extends ArgumentType<?>, T extends ArgumentSerializer.ArgumentTypeProperties<A>> void registerArgumentType(Identifier id, Class<A> clazz, ArgumentSerializer<A, T> serializer) {
-			var deferredRegister = DeferredRegister.create(RegistryKeys.COMMAND_ARGUMENT_TYPE, id.getNamespace());
-			deferredRegister.register(id.getPath(), () -> serializer);
-			deferredRegister.register(FMLJavaModLoadingContext.get().getModEventBus());
-			ArgumentTypes.registerByClass(clazz, serializer);
-		}
+                public <A extends ArgumentType<?>, T extends ArgumentSerializer.ArgumentTypeProperties<A>> void registerArgumentType(ResourceLocation id, Class<A> clazz, ArgumentSerializer<A, T> serializer) {
+                        var deferredRegister = DeferredRegister.create(RegistryKeys.COMMAND_ARGUMENT_TYPE, id.getNamespace());
+                        deferredRegister.register(id.getPath(), () -> serializer);
+                        deferredRegister.register(FMLJavaModLoadingContext.get().getModEventBus());
+                        ArgumentTypes.registerByClass(clazz, serializer);
+                }
 
 		@Override
-		public <T extends InPacket> void registerInPacket(Identifier identifier, Function<PacketByteBuf, T> reader, ServerPacketHandler<T> handler) {
-			var channel = NetworkRegistry.newEventChannel(
-					identifier,
-					() -> "1",
-					version -> true,
-					version -> true
+                public <T extends InPacket> void registerInPacket(ResourceLocation identifier, Function<FriendlyByteBuf, T> reader, ServerPacketHandler<T> handler) {
+                        var channel = NetworkRegistry.newEventChannel(
+                                        identifier,
+                                        () -> "1",
+                                        version -> true,
+                                        version -> true
 			);
 			channel.addListener(networkEvent -> {
 				var context = networkEvent.getSource().get();
@@ -143,15 +143,15 @@ public class ForgeMain {
 					return;
 				}
 				if (networkEvent instanceof NetworkEvent.ClientCustomPayloadEvent serverNetworkEvent) {
-					var packet = reader.apply(serverNetworkEvent.getPayload());
-					context.enqueueWork(() -> handler.handle(context.getSender(), packet));
-					context.setPacketHandled(true);
-				}
-			});
-		}
+                                        var packet = reader.apply(serverNetworkEvent.getPayload());
+                                        context.enqueueWork(() -> handler.handle(context.getSender(), packet));
+                                        context.setPacketHandled(true);
+                                }
+                        });
+                }
 
 		@Override
-		public void registerOutPacket(Identifier id) { }
+                public void registerOutPacket(ResourceLocation id) { }
 	}
 
 	private class ServerEventReceiverImpl implements ServerEventReceiver {
@@ -163,18 +163,18 @@ public class ForgeMain {
 
 	private static class ServerPacketSenderImpl implements ServerPacketSender {
 		@Override
-		public void send(ServerPlayerEntity player, OutPacket packet) {
-			var buf = new PacketByteBuf(Unpooled.buffer());
-			packet.write(buf);
-			player.networkHandler.sendPacket(new CustomPayloadS2CPacket(packet.getId(), buf));
-		}
-	}
+                public void send(ServerPlayer player, OutPacket packet) {
+                        var buf = new FriendlyByteBuf(Unpooled.buffer());
+                        packet.write(buf);
+                        player.connection.send(new ClientboundCustomPayloadPacket(packet.getId(), buf));
+                }
+        }
 
 	private static class ServerPlatformImpl implements ServerPlatform {
 		@Override
-		public boolean isFakePlayer(ServerPlayerEntity player) {
-			return player instanceof FakePlayer;
-		}
-	}
+                public boolean isFakePlayer(ServerPlayer player) {
+                        return player instanceof FakePlayer;
+                }
+        }
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.parallel=true
 
 # Yarn Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.20
-yarn_mappings=1.20+build.1
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.10
 
 # Mod Properties
 mod_version = 0.16.3
@@ -16,4 +16,4 @@ archives_base_name = puffish_skills_leveling
 mixin_version = 0.12.4+mixin.0.8.5
 junit_version = 5.7.1
 fabric_loader_version=0.14.21
-puffish_skills_dependency_version=0.16.4-1.20
+puffish_skills_dependency_version=0.16.3-1.20


### PR DESCRIPTION
## Summary
- Adapt Forge client side to Minecraft 1.20.1 networking and key mapping APIs
- Replace server networking classes with 1.20.1 equivalents and update packet registration/sending
- Update Gradle properties for Minecraft 1.20.1 and set skillsmod dependency version

## Testing
- `./gradlew :Forge:compileJava` *(fails: Could not find net.puffish:skillsmod:0.16.3-1.20)*

------
https://chatgpt.com/codex/tasks/task_e_688f8b4bd42083278274a94b3d0ead62