### PR TITLE
Add Common module to Forge build

### DIFF
--- a/Forge/build.gradle.kts
+++ b/Forge/build.gradle.kts
@@ -7,6 +7,8 @@ base.archivesName.set("${project.properties["archives_base_name"]}")
 version = "${project.properties["mod_version"]}-${project.properties["minecraft_version"]}-forge"
 group = "${project.properties["maven_group"]}"
 
+evaluationDependsOn(":Common")
+
 java {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
@@ -24,11 +26,20 @@ dependencies {
         forge("net.minecraftforge:forge:${project.properties["minecraft_version"]}-${project.properties["forge_version"]}")
 
         implementation("net.puffish:skillsmod:${project.properties["puffish_skills_dependency_version"]}:forge")
+        implementation(project(path = ":Common", configuration = "namedElements"))
 }
 
 loom {
         mixin.defaultRefmapName.set("puffish_skills_leveling-refmap.json")
         forge.mixinConfig("puffish_skills_leveling.mixins.json")
+}
+
+tasks.test {
+        dependsOn(project(":Common").tasks.test)
+}
+
+tasks.check {
+        dependsOn(project(":Common").tasks.check)
 }
 
 tasks.jar {
@@ -37,6 +48,8 @@ tasks.jar {
 }
 
 tasks.processResources {
+        from(project(":Common").sourceSets.main.get().resources)
+
         inputs.property("version", project.properties["mod_version"])
         filesMatching("META-INF/mods.toml") {
                 expand(
@@ -46,4 +59,8 @@ tasks.processResources {
                         )
                 )
         }
+}
+
+tasks.compileJava {
+        source(project(":Common").sourceSets.main.get().java)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,4 +14,4 @@ plugins {
 
 rootProject.name = "Pufferfish's Skills"
 
-include("Forge")
+include("Common", "Forge")


### PR DESCRIPTION
## Summary
- include Common project in Gradle settings
- wire shared Common sources and resources into Forge build configuration

## Testing
- `./gradlew --console=plain :Forge:compileJava` *(fails: class symbols like `Minecraft` and `FriendlyByteBuf` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbf7f28d08327814dccb5c3e3d7d9