### PR TITLE
Fix Forge module compilation by using Yarn mappings

### DIFF
--- a/Forge/src/main/java/net/puffish/skillsmod/main/ForgeClientMain.java
+++ b/Forge/src/main/java/net/puffish/skillsmod/main/ForgeClientMain.java
@@ -1,11 +1,11 @@
 package net.puffish.skillsmod.main;
 
 import io.netty.buffer.Unpooled;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.KeyMapping;
-import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.util.Identifier;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -30,7 +30,7 @@ import java.util.function.Function;
 
 public class ForgeClientMain {
 	private final List<ClientEventListener> clientListeners = new ArrayList<>();
-	private final List<KeyBindingWithHandler> keyBindings = new ArrayList<>();
+        private final List<KeyBindingWithHandler> keyBindings = new ArrayList<>();
 
 	public ForgeClientMain() {
 		var forgeEventBus = MinecraftForge.EVENT_BUS;
@@ -53,18 +53,18 @@ public class ForgeClientMain {
 
         private void onInputKey(InputEvent.Key event) {
                 for (var keyBinding : keyBindings) {
-                        if (keyBinding.keyBinding.consumeClick()) {
+                        if (keyBinding.keyBinding.wasPressed()) {
                                 keyBinding.handler.handle();
                         }
                 }
         }
 
-        private record KeyBindingWithHandler(KeyMapping keyBinding, KeyBindingHandler handler) {
+        private record KeyBindingWithHandler(KeyBinding keyBinding, KeyBindingHandler handler) {
         }
 
 	private static class ClientRegistrarImpl implements ClientRegistrar {
 		@Override
-                public <T extends InPacket> void registerInPacket(ResourceLocation identifier, Function<FriendlyByteBuf, T> reader, ClientPacketHandler<T> handler) {
+                public <T extends InPacket> void registerInPacket(Identifier identifier, Function<PacketByteBuf, T> reader, ClientPacketHandler<T> handler) {
 			var channel = NetworkRegistry.newEventChannel(
 					identifier,
 					() -> "1",
@@ -85,7 +85,7 @@ public class ForgeClientMain {
 		}
 
 		@Override
-                public void registerOutPacket(ResourceLocation id) { }
+                public void registerOutPacket(Identifier id) { }
 	}
 
 	private class ClientEventReceiverImpl implements ClientEventReceiver {
@@ -95,22 +95,22 @@ public class ForgeClientMain {
 		}
 	}
 
-	private class KeyBindingReceiverImpl implements KeyBindingReceiver {
-		@Override
-                public void registerKeyBinding(KeyMapping keyBinding, KeyBindingHandler handler) {
+        private class KeyBindingReceiverImpl implements KeyBindingReceiver {
+                @Override
+                public void registerKeyBinding(KeyBinding keyBinding, KeyBindingHandler handler) {
                         keyBindings.add(new KeyBindingWithHandler(keyBinding, handler));
-                        var options = Minecraft.getInstance().options;
-                        options.keyMappings = ArrayUtils.add(options.keyMappings, keyBinding);
+                        var options = MinecraftClient.getInstance().options;
+                        options.allKeys = ArrayUtils.add(options.allKeys, keyBinding);
                 }
         }
 
         private static class ClientPacketSenderImpl implements ClientPacketSender {
                 @Override
                 public void send(OutPacket packet) {
-                        var buf = new FriendlyByteBuf(Unpooled.buffer());
+                        var buf = new PacketByteBuf(Unpooled.buffer());
                         packet.write(buf);
-                        Objects.requireNonNull(Minecraft.getInstance().getConnection())
-                                        .send(new ServerboundCustomPayloadPacket(packet.getId(), buf));
+                        Objects.requireNonNull(MinecraftClient.getInstance().getNetworkHandler())
+                                        .sendPacket(new CustomPayloadC2SPacket(packet.getId(), buf));
                 }
         }
 }

--- a/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
+++ b/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
@@ -4,12 +4,12 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import io.netty.buffer.Unpooled;
 import net.minecraft.command.argument.ArgumentTypes;
 import net.minecraft.command.argument.serialize.ArgumentSerializer;
-import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKeys;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
 import net.minecraft.world.GameRules;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
@@ -66,7 +66,7 @@ public class ForgeMain {
 	}
 
         private void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
-                if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+                if (event.getEntity() instanceof ServerPlayerEntity serverPlayer) {
                         for (var listener : serverListeners) {
                                 listener.onPlayerJoin(serverPlayer);
                         }
@@ -74,7 +74,7 @@ public class ForgeMain {
         }
 
         private void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
-                if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+                if (event.getEntity() instanceof ServerPlayerEntity serverPlayer) {
                         for (var listener : serverListeners) {
                                 listener.onPlayerLeave(serverPlayer);
                         }
@@ -110,7 +110,7 @@ public class ForgeMain {
 
 	private static class ServerRegistrarImpl implements ServerRegistrar {
 		@Override
-                public <V, T extends V> void register(Registry<V> registry, ResourceLocation id, T entry) {
+                public <V, T extends V> void register(Registry<V> registry, Identifier id, T entry) {
                         var deferredRegister = DeferredRegister.create(registry.getKey(), id.getNamespace());
                         deferredRegister.register(id.getPath(), () -> entry);
                         deferredRegister.register(FMLJavaModLoadingContext.get().getModEventBus());
@@ -122,7 +122,7 @@ public class ForgeMain {
 		}
 
 		@Override
-                public <A extends ArgumentType<?>, T extends ArgumentSerializer.ArgumentTypeProperties<A>> void registerArgumentType(ResourceLocation id, Class<A> clazz, ArgumentSerializer<A, T> serializer) {
+                public <A extends ArgumentType<?>, T extends ArgumentSerializer.ArgumentTypeProperties<A>> void registerArgumentType(Identifier id, Class<A> clazz, ArgumentSerializer<A, T> serializer) {
                         var deferredRegister = DeferredRegister.create(RegistryKeys.COMMAND_ARGUMENT_TYPE, id.getNamespace());
                         deferredRegister.register(id.getPath(), () -> serializer);
                         deferredRegister.register(FMLJavaModLoadingContext.get().getModEventBus());
@@ -130,7 +130,7 @@ public class ForgeMain {
                 }
 
 		@Override
-                public <T extends InPacket> void registerInPacket(ResourceLocation identifier, Function<FriendlyByteBuf, T> reader, ServerPacketHandler<T> handler) {
+                public <T extends InPacket> void registerInPacket(Identifier identifier, Function<PacketByteBuf, T> reader, ServerPacketHandler<T> handler) {
                         var channel = NetworkRegistry.newEventChannel(
                                         identifier,
                                         () -> "1",
@@ -151,7 +151,7 @@ public class ForgeMain {
                 }
 
 		@Override
-                public void registerOutPacket(ResourceLocation id) { }
+                public void registerOutPacket(Identifier id) { }
 	}
 
 	private class ServerEventReceiverImpl implements ServerEventReceiver {
@@ -163,16 +163,16 @@ public class ForgeMain {
 
 	private static class ServerPacketSenderImpl implements ServerPacketSender {
 		@Override
-                public void send(ServerPlayer player, OutPacket packet) {
-                        var buf = new FriendlyByteBuf(Unpooled.buffer());
+                public void send(ServerPlayerEntity player, OutPacket packet) {
+                        var buf = new PacketByteBuf(Unpooled.buffer());
                         packet.write(buf);
-                        player.connection.send(new ClientboundCustomPayloadPacket(packet.getId(), buf));
+                        player.networkHandler.sendPacket(new CustomPayloadS2CPacket(packet.getId(), buf));
                 }
         }
 
-	private static class ServerPlatformImpl implements ServerPlatform {
-		@Override
-                public boolean isFakePlayer(ServerPlayer player) {
+        private static class ServerPlatformImpl implements ServerPlatform {
+                @Override
+                public boolean isFakePlayer(ServerPlayerEntity player) {
                         return player instanceof FakePlayer;
                 }
         }


### PR DESCRIPTION
## Summary
- use Yarn-based imports and types in Forge client code and key binding logic
- switch Forge server code to Yarn classes for players, identifiers, buffers, and packets

## Testing
- `./gradlew build` *(fails: SkillDefinitionConfigTest NoSuchElementException)*
- `./gradlew test` *(fails: SkillDefinitionConfigTest NoSuchElementException)*
- `./gradlew check` *(fails: SkillDefinitionConfigTest NoSuchElementException)*

------
https://chatgpt.com/codex/tasks/task_e_688fd38f5de483279204d7af3d74b593