### PR TITLE
Add client networking scaffolding and mixin bootstrap

### DIFF
--- a/Common/src/main/resources/puffish_skill_leveling.mixins.json
+++ b/Common/src/main/resources/puffish_skill_leveling.mixins.json
@@ -4,7 +4,9 @@
         "package": "net.bluelotuscoding.puffishskillleveling.mixin",
         "compatibilityLevel": "JAVA_17",
         "mixins": [],
-        "client": [],
+        "client": [
+                "MinecraftMixin"
+        ],
         "injectors": {
                 "defaultRequire": 1
         },

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/ForgeClientEventReceiver.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/ForgeClientEventReceiver.java
@@ -1,0 +1,30 @@
+package net.bluelotuscoding.puffishskillleveling.client;
+
+import net.puffish.skillsmod.client.event.ClientEventListener;
+import net.puffish.skillsmod.client.event.ClientEventReceiver;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
+import net.minecraftforge.common.MinecraftForge;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Bridges Forge's event bus to the Skills API's client event system.
+ * Currently only the player join event is forwarded.
+ */
+public class ForgeClientEventReceiver implements ClientEventReceiver {
+    private final List<ClientEventListener> listeners = new ArrayList<>();
+
+    public ForgeClientEventReceiver() {
+        MinecraftForge.EVENT_BUS.addListener((ClientPlayerNetworkEvent.LoggingIn event) -> {
+            for (ClientEventListener listener : listeners) {
+                listener.onPlayerJoin();
+            }
+        });
+    }
+
+    @Override
+    public void registerListener(ClientEventListener listener) {
+        listeners.add(listener);
+    }
+}

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/ForgeKeyBindingReceiver.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/ForgeKeyBindingReceiver.java
@@ -1,0 +1,30 @@
+package net.bluelotuscoding.puffishskillleveling.client;
+
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.puffish.skillsmod.client.keybinding.KeyBindingHandler;
+import net.puffish.skillsmod.client.keybinding.KeyBindingReceiver;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent.ClientTickEvent;
+
+import java.util.Arrays;
+
+/**
+ * Registers key bindings and invokes handlers when the keys are
+ * pressed.
+ */
+public class ForgeKeyBindingReceiver implements KeyBindingReceiver {
+    @Override
+    public void registerKeyBinding(KeyMapping key, KeyBindingHandler handler) {
+        Minecraft mc = Minecraft.getInstance();
+        KeyMapping[] old = mc.options.keyMappings;
+        KeyMapping[] arr = Arrays.copyOf(old, old.length + 1);
+        arr[old.length] = key;
+        mc.options.keyMappings = arr;
+        MinecraftForge.EVENT_BUS.addListener((ClientTickEvent event) -> {
+            while (key.consumeClick()) {
+                handler.handle();
+            }
+        });
+    }
+}

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/SkillsScreen.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/SkillsScreen.java
@@ -1,0 +1,19 @@
+package net.bluelotuscoding.puffishskillleveling.client;
+
+import net.minecraft.resources.ResourceLocation;
+import net.puffish.skillsmod.client.data.ClientCategoryData;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Wrapper around the base Skills screen that allows the addon to
+ * reside in its own package while still delegating rendering to the
+ * original implementation provided by the Skills mod.
+ */
+public class SkillsScreen extends net.puffish.skillsmod.client.gui.SkillsScreen {
+    public SkillsScreen(Map<ResourceLocation, ClientCategoryData> categories,
+                        Optional<ResourceLocation> openCategory) {
+        super(categories, openCategory);
+    }
+}

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/network/ForgeClientPacketSender.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/network/ForgeClientPacketSender.java
@@ -1,0 +1,22 @@
+package net.bluelotuscoding.puffishskillleveling.client.network;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
+import net.puffish.skillsmod.client.network.ClientPacketSender;
+import net.puffish.skillsmod.network.OutPacket;
+
+/**
+ * Forge implementation of the ClientPacketSender defined by the
+ * Skills API. It forwards packets to the server using the Forge
+ * networking utilities.
+ */
+public class ForgeClientPacketSender implements ClientPacketSender {
+    @Override
+    public void send(OutPacket packet) {
+        FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
+        packet.write(buf);
+        Minecraft.getInstance().getConnection().send(new ServerboundCustomPayloadPacket(packet.getId(), buf));
+    }
+}

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/network/ForgeClientRegistrar.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/client/network/ForgeClientRegistrar.java
@@ -1,0 +1,42 @@
+package net.bluelotuscoding.puffishskillleveling.client.network;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.puffish.skillsmod.client.network.ClientPacketHandler;
+import net.puffish.skillsmod.client.setup.ClientRegistrar;
+import net.puffish.skillsmod.network.InPacket;
+import net.minecraftforge.network.NetworkRegistry;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.event.EventNetworkChannel;
+
+import java.util.function.Function;
+
+/**
+ * Registers packet handlers on the Forge networking system for the
+ * Skills API. Incoming packets are decoded using the provided reader
+ * and forwarded to the supplied handler.
+ */
+public class ForgeClientRegistrar implements ClientRegistrar {
+    @Override
+    public <T extends InPacket> void registerInPacket(ResourceLocation id,
+            Function<FriendlyByteBuf, T> reader,
+            ClientPacketHandler<T> handler) {
+        EventNetworkChannel channel = NetworkRegistry.newEventChannel(id, () -> "1.0", s -> true, s -> true);
+        channel.addListener((NetworkEvent event) -> {
+            NetworkEvent.Context ctx = event.getSource().get();
+            if (ctx.getPacketHandled()) {
+                return;
+            }
+            if (event instanceof NetworkEvent.ServerCustomPayloadEvent payload) {
+                T packet = reader.apply(payload.getPayload());
+                ctx.enqueueWork(() -> handler.handle(packet));
+                ctx.setPacketHandled(true);
+            }
+        });
+    }
+
+    @Override
+    public void registerOutPacket(ResourceLocation id) {
+        // No registration required for client-to-server packets in Forge
+    }
+}

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/mixin/MinecraftMixin.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/mixin/MinecraftMixin.java
@@ -1,0 +1,30 @@
+package net.bluelotuscoding.puffishskillleveling.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.main.GameConfig;
+import net.puffish.skillsmod.client.SkillsClientMod;
+import net.bluelotuscoding.puffishskillleveling.client.ForgeClientEventReceiver;
+import net.bluelotuscoding.puffishskillleveling.client.ForgeKeyBindingReceiver;
+import net.bluelotuscoding.puffishskillleveling.client.network.ForgeClientPacketSender;
+import net.bluelotuscoding.puffishskillleveling.client.network.ForgeClientRegistrar;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Injects the Skills client bootstrap into the Minecraft client so
+ * that the addon can interact with the external Skills API.
+ */
+@Mixin(Minecraft.class)
+public abstract class MinecraftMixin {
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void puffish_skill_leveling$init(GameConfig config, CallbackInfo ci) {
+        SkillsClientMod.setup(
+                new ForgeClientRegistrar(),
+                new ForgeClientEventReceiver(),
+                new ForgeKeyBindingReceiver(),
+                new ForgeClientPacketSender()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Hook Skills client setup in `Minecraft` via mixin
- Implement Forge client packet sender/registrar
- Add keybinding and event bridge helpers for Skills UI

## Testing
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68909095da288327b5081a1b5814f5c3