### PR TITLE
feat: add skills commands

### DIFF
--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/CategoryCommand.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/CategoryCommand.java
@@ -1,0 +1,74 @@
+package net.bluelotuscoding.puffishskillleveling.command;
+
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.resources.ResourceLocation;
+import net.puffish.skillsmod.api.SkillsAPI;
+
+public final class CategoryCommand {
+    private CategoryCommand() {
+    }
+
+    public static LiteralArgumentBuilder<CommandSourceStack> create() {
+        return Commands.literal("category")
+                .requires(source -> source.hasPermission(2))
+                .then(Commands.literal("lock")
+                        .then(Commands.argument("players", EntityArgument.players())
+                                .then(Commands.argument("category", StringArgumentType.string())
+                                        .executes(context -> {
+                                            var players = EntityArgument.getPlayers(context, "players");
+                                            var categoryId = ResourceLocation.tryParse(StringArgumentType.getString(context, "category"));
+                                            if (categoryId == null) {
+                                                return 0;
+                                            }
+                                            SkillsAPI.getCategory(categoryId)
+                                                    .ifPresent(category -> {
+                                                        for (var player : players) {
+                                                            category.lock(player);
+                                                        }
+                                                    });
+                                            return players.size();
+                                        }))
+                        ))
+                .then(Commands.literal("unlock")
+                        .then(Commands.argument("players", EntityArgument.players())
+                                .then(Commands.argument("category", StringArgumentType.string())
+                                        .executes(context -> {
+                                            var players = EntityArgument.getPlayers(context, "players");
+                                            var categoryId = ResourceLocation.tryParse(StringArgumentType.getString(context, "category"));
+                                            if (categoryId == null) {
+                                                return 0;
+                                            }
+                                            SkillsAPI.getCategory(categoryId)
+                                                    .ifPresent(category -> {
+                                                        for (var player : players) {
+                                                            category.unlock(player);
+                                                        }
+                                                    });
+                                            return players.size();
+                                        }))
+                        ))
+                .then(Commands.literal("erase")
+                        .then(Commands.argument("players", EntityArgument.players())
+                                .then(Commands.argument("category", StringArgumentType.string())
+                                        .executes(context -> {
+                                            var players = EntityArgument.getPlayers(context, "players");
+                                            var categoryId = ResourceLocation.tryParse(StringArgumentType.getString(context, "category"));
+                                            if (categoryId == null) {
+                                                return 0;
+                                            }
+                                            SkillsAPI.getCategory(categoryId)
+                                                    .ifPresent(category -> {
+                                                        for (var player : players) {
+                                                            category.erase(player);
+                                                        }
+                                                    });
+                                            return players.size();
+                                        }))
+                        ));
+    }
+}
+

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/ExperienceCommand.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/ExperienceCommand.java
@@ -1,0 +1,65 @@
+package net.bluelotuscoding.puffishskillleveling.command;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.resources.ResourceLocation;
+import net.puffish.skillsmod.api.SkillsAPI;
+
+public final class ExperienceCommand {
+    private ExperienceCommand() {
+    }
+
+    public static LiteralArgumentBuilder<CommandSourceStack> create() {
+        return Commands.literal("experience")
+                .requires(source -> source.hasPermission(2))
+                .then(Commands.literal("add")
+                        .then(Commands.argument("players", EntityArgument.players())
+                                .then(Commands.argument("category", StringArgumentType.string())
+                                        .then(Commands.argument("amount", IntegerArgumentType.integer())
+                                                .executes(context -> {
+                                                    var players = EntityArgument.getPlayers(context, "players");
+                                                    var categoryId = ResourceLocation.tryParse(StringArgumentType.getString(context, "category"));
+                                                    var amount = IntegerArgumentType.getInteger(context, "amount");
+                                                    if (categoryId == null) {
+                                                        return 0;
+                                                    }
+                                                    SkillsAPI.getCategory(categoryId)
+                                                            .flatMap(cat -> cat.getExperience())
+                                                            .ifPresent(exp -> {
+                                                                for (var player : players) {
+                                                                    exp.addTotal(player, amount);
+                                                                }
+                                                            });
+                                                    return players.size();
+                                                }))
+                                ))
+                )
+                .then(Commands.literal("set")
+                        .then(Commands.argument("players", EntityArgument.players())
+                                .then(Commands.argument("category", StringArgumentType.string())
+                                        .then(Commands.argument("amount", IntegerArgumentType.integer())
+                                                .executes(context -> {
+                                                    var players = EntityArgument.getPlayers(context, "players");
+                                                    var categoryId = ResourceLocation.tryParse(StringArgumentType.getString(context, "category"));
+                                                    var amount = IntegerArgumentType.getInteger(context, "amount");
+                                                    if (categoryId == null) {
+                                                        return 0;
+                                                    }
+                                                    SkillsAPI.getCategory(categoryId)
+                                                            .flatMap(cat -> cat.getExperience())
+                                                            .ifPresent(exp -> {
+                                                                for (var player : players) {
+                                                                    exp.setTotal(player, amount);
+                                                                }
+                                                            });
+                                                    return players.size();
+                                                }))
+                                ))
+                );
+    }
+}
+

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/ModCommands.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/ModCommands.java
@@ -1,0 +1,17 @@
+package net.bluelotuscoding.puffishskillleveling.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+
+public final class ModCommands {
+    private ModCommands() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(CategoryCommand.create());
+        dispatcher.register(ExperienceCommand.create());
+        dispatcher.register(PointsCommand.create());
+        dispatcher.register(SkillsCommand.create());
+    }
+}
+

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/PointsCommand.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/PointsCommand.java
@@ -1,0 +1,63 @@
+package net.bluelotuscoding.puffishskillleveling.command;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.resources.ResourceLocation;
+import net.puffish.skillsmod.api.SkillsAPI;
+
+public final class PointsCommand {
+    private PointsCommand() {
+    }
+
+    public static LiteralArgumentBuilder<CommandSourceStack> create() {
+        return Commands.literal("points")
+                .requires(source -> source.hasPermission(2))
+                .then(Commands.literal("add")
+                        .then(Commands.argument("players", EntityArgument.players())
+                                .then(Commands.argument("category", StringArgumentType.string())
+                                        .then(Commands.argument("count", IntegerArgumentType.integer())
+                                                .executes(context -> {
+                                                    var players = EntityArgument.getPlayers(context, "players");
+                                                    var categoryId = ResourceLocation.tryParse(StringArgumentType.getString(context, "category"));
+                                                    var count = IntegerArgumentType.getInteger(context, "count");
+                                                    if (categoryId == null) {
+                                                        return 0;
+                                                    }
+                                                    SkillsAPI.getCategory(categoryId)
+                                                            .ifPresent(category -> {
+                                                                for (var player : players) {
+                                                                    category.addExtraPoints(player, count);
+                                                                }
+                                                            });
+                                                    return players.size();
+                                                }))
+                                ))
+                )
+                .then(Commands.literal("set")
+                        .then(Commands.argument("players", EntityArgument.players())
+                                .then(Commands.argument("category", StringArgumentType.string())
+                                        .then(Commands.argument("count", IntegerArgumentType.integer())
+                                                .executes(context -> {
+                                                    var players = EntityArgument.getPlayers(context, "players");
+                                                    var categoryId = ResourceLocation.tryParse(StringArgumentType.getString(context, "category"));
+                                                    var count = IntegerArgumentType.getInteger(context, "count");
+                                                    if (categoryId == null) {
+                                                        return 0;
+                                                    }
+                                                    SkillsAPI.getCategory(categoryId)
+                                                            .ifPresent(category -> {
+                                                                for (var player : players) {
+                                                                    category.setExtraPoints(player, count);
+                                                                }
+                                                            });
+                                                    return players.size();
+                                                }))
+                                ))
+                );
+    }
+}
+

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/SkillsCommand.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/SkillsCommand.java
@@ -1,0 +1,71 @@
+package net.bluelotuscoding.puffishskillleveling.command;
+
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.resources.ResourceLocation;
+import net.puffish.skillsmod.api.SkillsAPI;
+
+public final class SkillsCommand {
+    private SkillsCommand() {
+    }
+
+    public static LiteralArgumentBuilder<CommandSourceStack> create() {
+        return Commands.literal("skills")
+                .requires(source -> source.hasPermission(2))
+                .then(
+                        Commands.literal("unlock")
+                                .then(
+                                        Commands.argument("players", EntityArgument.players())
+                                                .then(
+                                                        Commands.argument("category", StringArgumentType.string())
+                                                                .then(
+                                                                        Commands.argument("skill", StringArgumentType.string())
+                                                                                .executes(context -> {
+                                                                                    var players = EntityArgument.getPlayers(context, "players");
+                                                                                    var categoryId = ResourceLocation.tryParse(StringArgumentType.getString(context, "category"));
+                                                                                    var skillId = StringArgumentType.getString(context, "skill");
+                                                                                    if (categoryId == null) {
+                                                                                        return 0;
+                                                                                    }
+                                                                                    SkillsAPI.getCategory(categoryId)
+                                                                                            .flatMap(cat -> cat.getSkill(skillId))
+                                                                                            .ifPresent(skill -> {
+                                                                                                for (var player : players) {
+                                                                                                    skill.unlock(player);
+                                                                                                }
+                                                                                            });
+                                                                                    return players.size();
+                                                                                })
+                                                                )
+                                                )
+                                )
+                )
+                .then(
+                        Commands.literal("reset")
+                                .then(
+                                        Commands.argument("players", EntityArgument.players())
+                                                .then(
+                                                        Commands.argument("category", StringArgumentType.string())
+                                                                .executes(context -> {
+                                                                    var players = EntityArgument.getPlayers(context, "players");
+                                                                    var categoryId = ResourceLocation.tryParse(StringArgumentType.getString(context, "category"));
+                                                                    if (categoryId == null) {
+                                                                        return 0;
+                                                                    }
+                                                                    SkillsAPI.getCategory(categoryId)
+                                                                            .ifPresent(category -> {
+                                                                                for (var player : players) {
+                                                                                    category.resetSkills(player);
+                                                                                }
+                                                                            });
+                                                                    return players.size();
+                                                                })
+                                                )
+                                )
+                );
+    }
+}
+

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/ForgeMain.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/ForgeMain.java
@@ -1,7 +1,10 @@
 package net.bluelotuscoding.puffishskillleveling;
 
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.puffish.skillsmod.api.SkillsAPI;
+import net.bluelotuscoding.puffishskillleveling.command.ModCommands;
 
 @Mod(PuffishSkillLeveling.MOD_ID)
 public final class ForgeMain {
@@ -11,5 +14,11 @@ public final class ForgeMain {
 
         // Register addon features.
         PuffishSkillLeveling.init();
+
+        MinecraftForge.EVENT_BUS.addListener(this::onRegisterCommands);
+    }
+
+    private void onRegisterCommands(RegisterCommandsEvent event) {
+        ModCommands.register(event.getDispatcher());
     }
 }


### PR DESCRIPTION
## Summary
- add skill, category, experience, and points commands using Skills API
- hook command registrar into Forge event bus

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68909096aba883278f6b07ae849f92e8