### PR TITLE
feat: add block experience sources

### DIFF
--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/PuffishSkillLeveling.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/PuffishSkillLeveling.java
@@ -1,6 +1,7 @@
 package net.bluelotuscoding.puffishskillleveling;
 
 import net.bluelotuscoding.puffishskillleveling.reward.PerLevelRewardsReward;
+import net.bluelotuscoding.puffishskillleveling.experience.source.BuiltinExperienceSources;
 
 /**
  * Common entry point for registering addon features.
@@ -13,6 +14,7 @@ public final class PuffishSkillLeveling {
      */
     public static void init() {
         PerLevelRewardsReward.register();
+        BuiltinExperienceSources.register();
     }
 
     private PuffishSkillLeveling() {

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/experience/source/BreakBlockExperienceSource.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/experience/source/BreakBlockExperienceSource.java
@@ -1,0 +1,103 @@
+package net.bluelotuscoding.puffishskillleveling.experience.source;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.resources.ResourceLocation;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.calculation.Calculation;
+import net.puffish.skillsmod.api.calculation.Variables;
+import net.puffish.skillsmod.api.calculation.operation.OperationFactory;
+import net.puffish.skillsmod.api.calculation.prototype.BuiltinPrototypes;
+import net.puffish.skillsmod.api.calculation.prototype.Prototype;
+import net.puffish.skillsmod.api.experience.source.ExperienceSource;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceConfigContext;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceDisposeContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+/**
+ * Grants experience when a player breaks a block with a tool.
+ */
+public class BreakBlockExperienceSource implements ExperienceSource {
+    public static final ResourceLocation ID = SkillsMod.createIdentifier("break_block");
+    private static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+
+    static {
+        PROTOTYPE.registerOperation(
+                SkillsMod.createIdentifier("get_player"),
+                BuiltinPrototypes.PLAYER,
+                OperationFactory.create(Data::player)
+        );
+        PROTOTYPE.registerOperation(
+                SkillsMod.createIdentifier("get_broken_block_state"),
+                BuiltinPrototypes.BLOCK_STATE,
+                OperationFactory.create(Data::blockState)
+        );
+        PROTOTYPE.registerOperation(
+                SkillsMod.createIdentifier("get_tool_item_stack"),
+                BuiltinPrototypes.ITEM_STACK,
+                OperationFactory.create(Data::tool)
+        );
+    }
+
+    private final Calculation<Data> calculation;
+
+    private BreakBlockExperienceSource(Calculation<Data> calculation) {
+        this.calculation = calculation;
+    }
+
+    public static void register() {
+        SkillsAPI.registerExperienceSource(ID, BreakBlockExperienceSource::parse);
+    }
+
+    private static Result<BreakBlockExperienceSource, Problem> parse(ExperienceSourceConfigContext context) {
+        return context.getData()
+                .andThen(JsonElement::getAsObject)
+                .andThen(obj -> obj.noUnused(o -> parse(o, context)));
+    }
+
+    private static Result<BreakBlockExperienceSource, Problem> parse(JsonObject rootObject, ExperienceSourceConfigContext context) {
+        var problems = new ArrayList<Problem>();
+
+        var variables = rootObject.get("variables")
+                .getSuccess()
+                .flatMap(variablesElement -> Variables.parse(variablesElement, PROTOTYPE, context)
+                        .ifFailure(problems::add)
+                        .getSuccess())
+                .orElseGet(() -> Variables.create(Map.of()));
+
+        var optCalculation = rootObject.get("experience")
+                .andThen(experienceElement -> Calculation.parse(
+                        experienceElement,
+                        variables,
+                        context
+                ))
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        if (problems.isEmpty()) {
+            return Result.success(new BreakBlockExperienceSource(optCalculation.orElseThrow()));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    private record Data(ServerPlayer player, BlockState blockState, ItemStack tool) { }
+
+    public int getValue(ServerPlayer player, BlockState blockState, ItemStack tool) {
+        return (int) Math.round(calculation.evaluate(new Data(player, blockState, tool)));
+    }
+
+    @Override
+    public void dispose(ExperienceSourceDisposeContext context) {
+        // Nothing to dispose.
+    }
+}
+

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/experience/source/BuiltinExperienceSources.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/experience/source/BuiltinExperienceSources.java
@@ -1,0 +1,15 @@
+package net.bluelotuscoding.puffishskillleveling.experience.source;
+
+/**
+ * Registers all builtin experience sources provided by this addon.
+ */
+public final class BuiltinExperienceSources {
+    public static void register() {
+        BreakBlockExperienceSource.register();
+        MineBlockExperienceSource.register();
+    }
+
+    private BuiltinExperienceSources() {
+    }
+}
+

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/experience/source/MineBlockExperienceSource.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/experience/source/MineBlockExperienceSource.java
@@ -1,0 +1,143 @@
+package net.bluelotuscoding.puffishskillleveling.experience.source;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.resources.ResourceLocation;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.calculation.Calculation;
+import net.puffish.skillsmod.api.calculation.operation.OperationFactory;
+import net.puffish.skillsmod.api.calculation.prototype.BuiltinPrototypes;
+import net.puffish.skillsmod.api.calculation.prototype.Prototype;
+import net.puffish.skillsmod.api.experience.source.ExperienceSource;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceConfigContext;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceDisposeContext;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.calculation.LegacyBuiltinPrototypes;
+import net.puffish.skillsmod.calculation.LegacyCalculation;
+import net.puffish.skillsmod.calculation.operation.LegacyOperationRegistry;
+import net.puffish.skillsmod.calculation.operation.builtin.AttributeOperation;
+import net.puffish.skillsmod.calculation.operation.builtin.BlockStateCondition;
+import net.puffish.skillsmod.calculation.operation.builtin.EffectOperation;
+import net.puffish.skillsmod.calculation.operation.builtin.ItemStackCondition;
+import net.puffish.skillsmod.calculation.operation.builtin.legacy.LegacyBlockTagCondition;
+import net.puffish.skillsmod.calculation.operation.builtin.legacy.LegacyItemTagCondition;
+
+/**
+ * Grants experience for mining blocks.
+ */
+public class MineBlockExperienceSource implements ExperienceSource {
+    public static final ResourceLocation ID = SkillsMod.createIdentifier("mine_block");
+    private static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+
+    static {
+        PROTOTYPE.registerOperation(
+                SkillsMod.createIdentifier("get_player"),
+                BuiltinPrototypes.PLAYER,
+                OperationFactory.create(Data::player)
+        );
+        PROTOTYPE.registerOperation(
+                SkillsMod.createIdentifier("get_mined_block_state"),
+                BuiltinPrototypes.BLOCK_STATE,
+                OperationFactory.create(Data::blockState)
+        );
+        PROTOTYPE.registerOperation(
+                SkillsMod.createIdentifier("get_tool_item_stack"),
+                BuiltinPrototypes.ITEM_STACK,
+                OperationFactory.create(Data::tool)
+        );
+    }
+
+    private final Calculation<Data> calculation;
+
+    private MineBlockExperienceSource(Calculation<Data> calculation) {
+        this.calculation = calculation;
+    }
+
+    public static void register() {
+        SkillsAPI.registerExperienceSource(ID, MineBlockExperienceSource::parse);
+    }
+
+    private static Result<MineBlockExperienceSource, Problem> parse(ExperienceSourceConfigContext context) {
+        return context.getData().andThen(rootElement ->
+                LegacyCalculation.parse(rootElement, PROTOTYPE, context)
+                        .mapSuccess(MineBlockExperienceSource::new)
+        );
+    }
+
+    private record Data(ServerPlayer player, BlockState blockState, ItemStack tool) { }
+
+    public int getValue(ServerPlayer player, BlockState blockState, ItemStack tool) {
+        return (int) Math.round(calculation.evaluate(new Data(player, blockState, tool)));
+    }
+
+    @Override
+    public void dispose(ExperienceSourceDisposeContext context) {
+        // Nothing to do.
+    }
+
+    static {
+        var legacy = new LegacyOperationRegistry<>(PROTOTYPE);
+        legacy.registerBooleanFunction(
+                "block",
+                BlockStateCondition::parse,
+                Data::blockState
+        );
+        legacy.registerBooleanFunction(
+                "block_state",
+                BlockStateCondition::parse,
+                Data::blockState
+        );
+        legacy.registerBooleanFunction(
+                "block_tag",
+                LegacyBlockTagCondition::parse,
+                Data::blockState
+        );
+        legacy.registerBooleanFunction(
+                "tool",
+                ItemStackCondition::parse,
+                Data::tool
+        );
+        legacy.registerBooleanFunction(
+                "tool_nbt",
+                ItemStackCondition::parse,
+                Data::tool
+        );
+        legacy.registerBooleanFunction(
+                "tool_tag",
+                LegacyItemTagCondition::parse,
+                Data::tool
+        );
+        legacy.registerNumberFunction(
+                "player_effect",
+                effect -> (double) (effect.getAmplifier() + 1),
+                EffectOperation::parse,
+                Data::player
+        );
+        legacy.registerNumberFunction(
+                "player_attribute",
+                net.minecraft.world.entity.ai.attributes.AttributeInstance::getValue,
+                AttributeOperation::parse,
+                Data::player
+        );
+
+        LegacyBuiltinPrototypes.registerAlias(
+                PROTOTYPE,
+                SkillsMod.createIdentifier("player"),
+                SkillsMod.createIdentifier("get_player")
+        );
+        LegacyBuiltinPrototypes.registerAlias(
+                PROTOTYPE,
+                SkillsMod.createIdentifier("mined_block_state"),
+                SkillsMod.createIdentifier("get_mined_block_state")
+        );
+        LegacyBuiltinPrototypes.registerAlias(
+                PROTOTYPE,
+                SkillsMod.createIdentifier("tool_item_stack"),
+                SkillsMod.createIdentifier("get_tool_item_stack")
+        );
+    }
+}
+

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/ForgeMain.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/ForgeMain.java
@@ -2,6 +2,7 @@ package net.bluelotuscoding.puffishskillleveling;
 
 import net.minecraftforge.fml.common.Mod;
 import net.puffish.skillsmod.api.SkillsAPI;
+import net.bluelotuscoding.puffishskillleveling.experience.source.ExperienceEvents;
 
 @Mod(PuffishSkillLeveling.MOD_ID)
 public final class ForgeMain {
@@ -11,5 +12,6 @@ public final class ForgeMain {
 
         // Register addon features.
         PuffishSkillLeveling.init();
+        ExperienceEvents.register();
     }
 }

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/experience/source/ExperienceEvents.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/experience/source/ExperienceEvents.java
@@ -1,0 +1,37 @@
+package net.bluelotuscoding.puffishskillleveling.experience.source;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.event.level.BlockEvent;
+import net.puffish.skillsmod.api.SkillsAPI;
+
+/**
+ * Handles Forge events to feed data into experience sources.
+ */
+public final class ExperienceEvents {
+    public static void register() {
+        MinecraftForge.EVENT_BUS.register(new ExperienceEvents());
+    }
+
+    @SubscribeEvent
+    public void onBreakBlock(BlockEvent.BreakEvent event) {
+        if (!(event.getPlayer() instanceof ServerPlayer player)) {
+            return;
+        }
+        BlockState state = event.getState();
+        ItemStack tool = player.getMainHandItem();
+        SkillsAPI.updateExperienceSources(player, source -> {
+            if (source instanceof BreakBlockExperienceSource breakSource) {
+                return breakSource.getValue(player, state, tool);
+            }
+            if (source instanceof MineBlockExperienceSource mineSource) {
+                return mineSource.getValue(player, state, tool);
+            }
+            return 0;
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add break block experience source hooked into Forge events
- register builtin experience sources during addon initialization
- update Forge entry point to install experience event listener

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68909097551083278b31f8ed96026f13