### PR TITLE
Add legacy built-in rewards

### DIFF
--- a/Common/build.gradle.kts
+++ b/Common/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     compileOnly("net.fabricmc:sponge-mixin:${project.properties["mixin_version"]}")
     compileOnly("net.puffish:skillsmod:${project.properties["puffish_skills_dependency_version"]}:forge")
+    compileOnly("org.apache.commons:commons-lang3:${project.properties["commons_lang_version"]}")
 
     testImplementation("org.junit.jupiter:junit-jupiter:${project.properties["junit_version"]}")
 }

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/PuffishSkillLeveling.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/PuffishSkillLeveling.java
@@ -1,6 +1,12 @@
 package net.bluelotuscoding.puffishskillleveling;
 
+import net.bluelotuscoding.puffishskillleveling.reward.AttributeReward;
+import net.bluelotuscoding.puffishskillleveling.reward.CommandReward;
+import net.bluelotuscoding.puffishskillleveling.reward.DummyReward;
 import net.bluelotuscoding.puffishskillleveling.reward.PerLevelRewardsReward;
+import net.bluelotuscoding.puffishskillleveling.reward.PointsReward;
+import net.bluelotuscoding.puffishskillleveling.reward.ScoreboardReward;
+import net.bluelotuscoding.puffishskillleveling.reward.TagReward;
 
 /**
  * Common entry point for registering addon features.
@@ -12,7 +18,13 @@ public final class PuffishSkillLeveling {
      * Registers custom rewards with the base Skills API.
      */
     public static void init() {
+        AttributeReward.register();
+        CommandReward.register();
+        DummyReward.register();
         PerLevelRewardsReward.register();
+        PointsReward.register();
+        ScoreboardReward.register();
+        TagReward.register();
     }
 
     private PuffishSkillLeveling() {

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/AttributeReward.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/AttributeReward.java
@@ -1,0 +1,122 @@
+package net.bluelotuscoding.puffishskillleveling.reward;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation;
+import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.json.BuiltinJson;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.reward.Reward;
+import net.puffish.skillsmod.api.reward.RewardConfigContext;
+import net.puffish.skillsmod.api.reward.RewardDisposeContext;
+import net.puffish.skillsmod.api.reward.RewardUpdateContext;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.util.LegacyUtils;
+
+/**
+ * Reward that adds attribute modifiers to players.
+ */
+public class AttributeReward implements Reward {
+    public static final ResourceLocation ID = SkillsMod.createIdentifier("attribute");
+
+    private final List<UUID> uuids = new ArrayList<>();
+    private final Attribute attribute;
+    private final float value;
+    private final Operation operation;
+
+    private AttributeReward(Attribute attribute, float value, Operation operation) {
+        this.attribute = attribute;
+        this.value = value;
+        this.operation = operation;
+    }
+
+    public static void register() {
+        SkillsAPI.registerReward(ID, AttributeReward::parse);
+    }
+
+    private static Result<AttributeReward, Problem> parse(RewardConfigContext context) {
+        return context.getData()
+                .andThen(JsonElement::getAsObject)
+                .andThen(LegacyUtils.wrapNoUnused(AttributeReward::parse, context));
+    }
+
+    private static Result<AttributeReward, Problem> parse(JsonObject rootObject) {
+        var problems = new ArrayList<Problem>();
+
+        Optional<Attribute> optAttribute = rootObject.get("attribute")
+                .andThen(element -> BuiltinJson.parseAttribute(element).andThen(attribute -> {
+                    if (DefaultAttributes.getSupplier(EntityType.PLAYER).hasAttribute(attribute)) {
+                        return Result.success(attribute);
+                    }
+                    return Result.failure(element.getPath().createProblem("Expected a valid player attribute"));
+                }))
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        Optional<Float> optValue = rootObject.getFloat("value")
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        Optional<Operation> optOperation = rootObject.get("operation")
+                .andThen(BuiltinJson::parseAttributeOperation)
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        if (problems.isEmpty()) {
+            return Result.success(new AttributeReward(
+                    optAttribute.orElseThrow(),
+                    optValue.orElseThrow(),
+                    optOperation.orElseThrow()));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    private void createMissingUUIDs(int count) {
+        while (uuids.size() < count) {
+            uuids.add(UUID.randomUUID());
+        }
+    }
+
+    @Override
+    public void update(RewardUpdateContext context) {
+        int count = context.getCount();
+        AttributeInstance instance = Objects.requireNonNull(context.getPlayer().getAttribute(attribute));
+        createMissingUUIDs(count);
+        for (int i = 0; i < uuids.size(); i++) {
+            UUID uuid = uuids.get(i);
+            if (instance.getModifier(uuid) == null) {
+                if (i < count) {
+                    instance.addTransientModifier(new AttributeModifier(uuid, "", value, operation));
+                }
+            } else if (i >= count) {
+                instance.removeModifier(uuid);
+            }
+        }
+    }
+
+    @Override
+    public void dispose(RewardDisposeContext context) {
+        for (ServerPlayer player : context.getServer().getPlayerList().getPlayers()) {
+            AttributeInstance instance = Objects.requireNonNull(player.getAttribute(attribute));
+            for (UUID uuid : uuids) {
+                instance.removeModifier(uuid);
+            }
+        }
+        uuids.clear();
+    }
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/CommandReward.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/CommandReward.java
@@ -1,0 +1,122 @@
+package net.bluelotuscoding.puffishskillleveling.reward;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.reward.Reward;
+import net.puffish.skillsmod.api.reward.RewardConfigContext;
+import net.puffish.skillsmod.api.reward.RewardDisposeContext;
+import net.puffish.skillsmod.api.reward.RewardUpdateContext;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.util.LegacyUtils;
+
+/**
+ * Reward that runs commands when unlocked or locked.
+ */
+public class CommandReward implements Reward {
+    public static final ResourceLocation ID = SkillsMod.createIdentifier("command");
+
+    private final Map<UUID, Integer> counts = new HashMap<>();
+    private final String command;
+    private final String unlockCommand;
+    private final String lockCommand;
+
+    private CommandReward(String command, String unlockCommand, String lockCommand) {
+        this.command = command;
+        this.unlockCommand = unlockCommand;
+        this.lockCommand = lockCommand;
+    }
+
+    public static void register() {
+        SkillsAPI.registerReward(ID, CommandReward::parse);
+    }
+
+    private static Result<CommandReward, Problem> parse(RewardConfigContext context) {
+        return context.getData()
+                .andThen(JsonElement::getAsObject)
+                .andThen(LegacyUtils.wrapNoUnused(CommandReward::parse, context));
+    }
+
+    private static Result<CommandReward, Problem> parse(JsonObject rootObject) {
+        var problems = new ArrayList<Problem>();
+
+        String command = rootObject.get("command")
+                .getSuccess()
+                .flatMap(e -> e.getAsString().ifFailure(problems::add).getSuccess())
+                .orElse("");
+
+        String unlockCommand = rootObject.get("unlock_command")
+                .getSuccess()
+                .flatMap(e -> e.getAsString().ifFailure(problems::add).getSuccess())
+                .orElse("");
+
+        String lockCommand = rootObject.get("lock_command")
+                .getSuccess()
+                .flatMap(e -> e.getAsString().ifFailure(problems::add).getSuccess())
+                .orElse("");
+
+        if (problems.isEmpty()) {
+            return Result.success(new CommandReward(command, unlockCommand, lockCommand));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    private void executeCommand(ServerPlayer player, String command) {
+        if (command.isBlank()) {
+            return;
+        }
+        MinecraftServer server = Objects.requireNonNull(player.getServer());
+        CommandSourceStack source = player.createCommandSourceStack()
+                .withPermission(server.getFunctionCompilationLevel());
+        server.getCommands().performPrefixedCommand(source, command);
+    }
+
+    @Override
+    public void update(RewardUpdateContext context) {
+        ServerPlayer player = context.getPlayer();
+        if (context.isAction()) {
+            executeCommand(player, command);
+        }
+        counts.compute(player.getUUID(), (uuid, count) -> {
+            if (count == null) {
+                count = 0;
+            }
+            while (context.getCount() > count) {
+                executeCommand(player, unlockCommand);
+                count++;
+            }
+            while (context.getCount() < count) {
+                executeCommand(player, lockCommand);
+                count--;
+            }
+            return count;
+        });
+    }
+
+    @Override
+    public void dispose(RewardDisposeContext context) {
+        for (Map.Entry<UUID, Integer> entry : counts.entrySet()) {
+            ServerPlayer player = context.getServer().getPlayerList().getPlayer(entry.getKey());
+            if (player == null) {
+                continue;
+            }
+            for (int i = 0; i < entry.getValue(); i++) {
+                executeCommand(player, lockCommand);
+            }
+        }
+        counts.clear();
+    }
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/DummyReward.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/DummyReward.java
@@ -1,0 +1,36 @@
+package net.bluelotuscoding.puffishskillleveling.reward;
+
+import net.minecraft.resources.ResourceLocation;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.reward.Reward;
+import net.puffish.skillsmod.api.reward.RewardConfigContext;
+import net.puffish.skillsmod.api.reward.RewardDisposeContext;
+import net.puffish.skillsmod.api.reward.RewardUpdateContext;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+
+/**
+ * No-op reward used as a placeholder.
+ */
+public class DummyReward implements Reward {
+    public static final ResourceLocation ID = SkillsMod.createIdentifier("dummy");
+
+    public static void register() {
+        SkillsAPI.registerReward(ID, DummyReward::parse);
+    }
+
+    private static Result<DummyReward, Problem> parse(RewardConfigContext context) {
+        return Result.success(new DummyReward());
+    }
+
+    @Override
+    public void update(RewardUpdateContext context) {
+        // no-op
+    }
+
+    @Override
+    public void dispose(RewardDisposeContext context) {
+        // no-op
+    }
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/PointsReward.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/PointsReward.java
@@ -1,0 +1,101 @@
+package net.bluelotuscoding.puffishskillleveling.reward;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.json.BuiltinJson;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.reward.Reward;
+import net.puffish.skillsmod.api.reward.RewardConfigContext;
+import net.puffish.skillsmod.api.reward.RewardDisposeContext;
+import net.puffish.skillsmod.api.reward.RewardUpdateContext;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import org.apache.commons.lang3.RandomStringUtils;
+
+/**
+ * Reward that grants points to a specific category using a temporary source id.
+ */
+public class PointsReward implements Reward {
+    public static final ResourceLocation ID = SkillsMod.createIdentifier("points");
+    private static final String PREFIX = "points_reward.";
+
+    private final ResourceLocation categoryId;
+    private final int points;
+    private final ResourceLocation source;
+
+    private PointsReward(ResourceLocation categoryId, int points, ResourceLocation source) {
+        this.categoryId = categoryId;
+        this.points = points;
+        this.source = source;
+    }
+
+    public static void register() {
+        SkillsAPI.registerReward(ID, PointsReward::parse);
+    }
+
+    private static Result<PointsReward, Problem> parse(RewardConfigContext context) {
+        return context.getData()
+                .andThen(JsonElement::getAsObject)
+                .andThen(obj -> obj.noUnused(PointsReward::parse));
+    }
+
+    private static Result<PointsReward, Problem> parse(JsonObject rootObject) {
+        var problems = new ArrayList<Problem>();
+
+        Optional<ResourceLocation> optCategory = rootObject.get("category")
+                .andThen(BuiltinJson::parseIdentifier)
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        Optional<Integer> optPoints = rootObject.getInt("points")
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        if (problems.isEmpty()) {
+            var source = SkillsMod.createIdentifier(
+                    PREFIX + RandomStringUtils.random(16, "abcdefghijklmnopqrstuvwxyz0123456789"));
+            return Result.success(new PointsReward(optCategory.orElseThrow(), optPoints.orElseThrow(), source));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    public static void cleanup(ServerPlayer player) {
+        SkillsAPI.streamCategories().forEach(category -> {
+            List<ResourceLocation> sources = category.streamPointsSources(player)
+                    .filter(src -> src.getNamespace().equals("puffish_skills"))
+                    .filter(src -> src.getPath().startsWith(PREFIX))
+                    .toList();
+            for (var src : sources) {
+                category.setPoints(player, src, 0);
+            }
+        });
+    }
+
+    @Override
+    public void update(RewardUpdateContext context) {
+        SkillsAPI.getCategory(categoryId).ifPresent(category -> {
+            int amount = points * context.getCount();
+            if (context.isAction()) {
+                category.setPoints(context.getPlayer(), source, amount);
+            } else {
+                category.setPointsSilently(context.getPlayer(), source, amount);
+            }
+        });
+    }
+
+    @Override
+    public void dispose(RewardDisposeContext context) {
+        SkillsAPI.getCategory(categoryId).ifPresent(category -> {
+            context.getServer().getPlayerList().getPlayers()
+                    .forEach(player -> category.setPoints(player, source, 0));
+        });
+    }
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/ScoreboardReward.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/ScoreboardReward.java
@@ -1,0 +1,74 @@
+package net.bluelotuscoding.puffishskillleveling.reward;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.scores.Objective;
+import net.minecraft.world.scores.Scoreboard;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.reward.Reward;
+import net.puffish.skillsmod.api.reward.RewardConfigContext;
+import net.puffish.skillsmod.api.reward.RewardDisposeContext;
+import net.puffish.skillsmod.api.reward.RewardUpdateContext;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.util.LegacyUtils;
+
+/**
+ * Reward that sets a scoreboard objective to the current count.
+ */
+public class ScoreboardReward implements Reward {
+    public static final ResourceLocation ID = SkillsMod.createIdentifier("scoreboard");
+
+    private final String objectiveName;
+
+    private ScoreboardReward(String objectiveName) {
+        this.objectiveName = objectiveName;
+    }
+
+    public static void register() {
+        SkillsAPI.registerReward(ID, ScoreboardReward::parse);
+    }
+
+    private static Result<ScoreboardReward, Problem> parse(RewardConfigContext context) {
+        return context.getData()
+                .andThen(JsonElement::getAsObject)
+                .andThen(LegacyUtils.wrapNoUnused(root -> parse(root, context), context));
+    }
+
+    private static Result<ScoreboardReward, Problem> parse(JsonObject rootObject, RewardConfigContext context) {
+        var problems = new ArrayList<Problem>();
+
+        Optional<String> optObjective = rootObject.getString("objective")
+                .orElse(LegacyUtils.wrapDeprecated(() -> rootObject.getString("scoreboard"), 3, context))
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        if (problems.isEmpty()) {
+            return Result.success(new ScoreboardReward(optObjective.orElseThrow()));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    @Override
+    public void update(RewardUpdateContext context) {
+        ServerPlayer player = context.getPlayer();
+        Scoreboard scoreboard = player.getScoreboard();
+        Objective objective = scoreboard.getObjective(objectiveName);
+        if (objective != null) {
+            scoreboard.getOrCreatePlayerScore(player.getScoreboardName(), objective)
+                    .setScore(context.getCount());
+        }
+    }
+
+    @Override
+    public void dispose(RewardDisposeContext context) {
+        // nothing to clean up
+    }
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/TagReward.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/reward/TagReward.java
@@ -1,0 +1,70 @@
+package net.bluelotuscoding.puffishskillleveling.reward;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.reward.Reward;
+import net.puffish.skillsmod.api.reward.RewardConfigContext;
+import net.puffish.skillsmod.api.reward.RewardDisposeContext;
+import net.puffish.skillsmod.api.reward.RewardUpdateContext;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.util.LegacyUtils;
+
+/**
+ * Reward that toggles a scoreboard tag on the player.
+ */
+public class TagReward implements Reward {
+    public static final ResourceLocation ID = SkillsMod.createIdentifier("tag");
+
+    private final String tag;
+
+    private TagReward(String tag) {
+        this.tag = tag;
+    }
+
+    public static void register() {
+        SkillsAPI.registerReward(ID, TagReward::parse);
+    }
+
+    private static Result<TagReward, Problem> parse(RewardConfigContext context) {
+        return context.getData()
+                .andThen(JsonElement::getAsObject)
+                .andThen(LegacyUtils.wrapNoUnused(TagReward::parse, context));
+    }
+
+    private static Result<TagReward, Problem> parse(JsonObject rootObject) {
+        var problems = new ArrayList<Problem>();
+
+        Optional<String> optTag = rootObject.getString("tag")
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        if (problems.isEmpty()) {
+            return Result.success(new TagReward(optTag.orElseThrow()));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    @Override
+    public void update(RewardUpdateContext context) {
+        ServerPlayer player = context.getPlayer();
+        if (context.getCount() > 0) {
+            player.addTag(tag);
+        } else {
+            player.removeTag(tag);
+        }
+    }
+
+    @Override
+    public void dispose(RewardDisposeContext context) {
+        // nothing to clean up
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ archives_base_name = puffish_skill_leveling
 mixin_version = 0.12.4+mixin.0.8.5
 junit_version = 5.7.1
 puffish_skills_dependency_version=0.16.0+1.20
+commons_lang_version=3.12.0


### PR DESCRIPTION
## Summary
- port built-in rewards (points, command, attribute, scoreboard, tag, dummy)
- register new rewards during addon initialization
- depend on commons-lang for RandomStringUtils

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_689090984e0c8327a490b40d6f55eb7e