### PR TITLE
Add skill refund command

### DIFF
--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/SkillsRefundCommand.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/SkillsRefundCommand.java
@@ -1,0 +1,86 @@
+package net.bluelotuscoding.puffishskillleveling.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.server.level.ServerPlayer;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.Category;
+import net.puffish.skillsmod.api.Skill;
+import net.puffish.skillsmod.commands.arguments.CategoryArgumentType;
+import net.puffish.skillsmod.commands.arguments.SkillArgumentType;
+import net.puffish.skillsmod.util.CommandUtils;
+
+import java.util.Collection;
+
+/**
+ * Command that refunds levels from a skill for one or more players.
+ */
+public final class SkillsRefundCommand {
+    private SkillsRefundCommand() {
+    }
+
+    /**
+     * Builds the {@code refund} subcommand for the {@code skills} command.
+     */
+    public static LiteralArgumentBuilder<CommandSourceStack> create() {
+        return Commands.literal("refund")
+                .then(Commands.argument("players", EntityArgument.players())
+                        .then(Commands.argument("category", CategoryArgumentType.category())
+                                .then(Commands.argument("skill", SkillArgumentType.skillFromCategory("category"))
+                                        .executes(ctx -> refund(ctx, 1))
+                                        .then(Commands.argument("count", IntegerArgumentType.integer(1))
+                                                .executes(ctx -> refund(ctx, IntegerArgumentType.getInteger(ctx, "count"))))
+                                        .then(Commands.literal("all")
+                                                .executes(ctx -> refund(ctx, -1)))
+                                )));
+    }
+
+    private static int refund(CommandContext<CommandSourceStack> context, int count) throws CommandSyntaxException {
+        Collection<ServerPlayer> players = EntityArgument.getPlayers(context, "players");
+        Category category = CategoryArgumentType.getCategory(context, "category");
+        Skill skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
+
+        int total = 0;
+        for (ServerPlayer player : players) {
+            total += SkillsRefundHelper.refundSkill(player, skill, count);
+        }
+
+        if (total == 0) {
+            context.getSource().sendFailure(SkillsMod.createTranslatable("command",
+                    "puffish_skills.skills.refund.no_levels",
+                    skill.getId(), category.getId()));
+            return 0;
+        }
+
+        if (count < 0) {
+            CommandUtils.sendSuccess(context, players, "skills.refund_all",
+                    skill.getId(), category.getId());
+        } else if (count == 1) {
+            CommandUtils.sendSuccess(context, players, "skills.refund",
+                    skill.getId(), category.getId());
+        } else {
+            CommandUtils.sendSuccess(context, players, "skills.refund_many",
+                    count, skill.getId(), category.getId());
+        }
+        return total;
+    }
+
+    /**
+     * Attaches this subcommand to the existing {@code /puffish_skills skills} command tree.
+     */
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        var root = dispatcher.getRoot().getChild("puffish_skills");
+        if (root != null) {
+            var skills = root.getChild("skills");
+            if (skills != null) {
+                skills.addChild(create().build());
+            }
+        }
+    }
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/SkillsRefundHelper.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/command/SkillsRefundHelper.java
@@ -1,0 +1,29 @@
+package net.bluelotuscoding.puffishskillleveling.command;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.puffish.skillsmod.api.Skill;
+
+/**
+ * Utility for decrementing skill levels when refunding points.
+ */
+public final class SkillsRefundHelper {
+    private SkillsRefundHelper() {
+    }
+
+    /**
+     * Refunds a number of levels from the given skill.
+     *
+     * @param player player whose skill should be decremented
+     * @param skill skill to modify
+     * @param count number of levels to refund, or negative to refund all
+     * @return number of levels actually refunded
+     */
+    public static int refundSkill(ServerPlayer player, Skill skill, int count) {
+        int refunded = 0;
+        while ((count < 0 || refunded < count) && skill.getState(player) == Skill.State.UNLOCKED) {
+            skill.lock(player);
+            refunded++;
+        }
+        return refunded;
+    }
+}

--- a/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/ForgeMain.java
+++ b/Forge/src/main/java/net/bluelotuscoding/puffishskillleveling/ForgeMain.java
@@ -1,7 +1,10 @@
 package net.bluelotuscoding.puffishskillleveling;
 
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.puffish.skillsmod.api.SkillsAPI;
+import net.bluelotuscoding.puffishskillleveling.command.SkillsRefundCommand;
 
 @Mod(PuffishSkillLeveling.MOD_ID)
 public final class ForgeMain {
@@ -11,5 +14,12 @@ public final class ForgeMain {
 
         // Register addon features.
         PuffishSkillLeveling.init();
+
+        // Hook command registration to extend the /puffish_skills command tree.
+        MinecraftForge.EVENT_BUS.addListener(ForgeMain::registerCommands);
+    }
+
+    private static void registerCommands(RegisterCommandsEvent event) {
+        SkillsRefundCommand.register(event.getDispatcher());
     }
 }


### PR DESCRIPTION
## Summary
- add `SkillsRefundHelper` utility to decrement skill levels
- implement `SkillsRefundCommand` for `/puffish_skills skills refund`
- register new command on Forge

## Testing
- `./gradlew build`
- `./gradlew check`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6890b36823448327abcac494ec69c434