### PR TITLE
Add Skills mod dependency

### DIFF
--- a/Common/build.gradle.kts
+++ b/Common/build.gradle.kts
@@ -7,6 +7,10 @@ base.archivesName.set("${project.properties["archives_base_name"]}")
 version = "${project.properties["mod_version"]}-${project.properties["minecraft_version"]}-common"
 group = "${project.properties["maven_group"]}"
 
+repositories {
+    maven("https://maven.puffish.net")
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17

--- a/Fabric/build.gradle.kts
+++ b/Fabric/build.gradle.kts
@@ -9,6 +9,10 @@ group = "${project.properties["maven_group"]}"
 
 evaluationDependsOn(":Common")
 
+repositories {
+    maven("https://maven.puffish.net")
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
@@ -20,6 +24,7 @@ dependencies {
 
     modImplementation("net.fabricmc:fabric-loader:${project.properties["fabric_loader_version"]}")
     modImplementation("net.fabricmc.fabric-api:fabric-api:${project.properties["fabric_api_version"]}")
+    modImplementation("net.puffish:skillsmod:${project.properties["skillsmod_version"]}:fabric")
 
     implementation(project(path = ":Common", configuration = "namedElements"))
 }

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -20,10 +20,11 @@
 	"mixins": [
 		"puffish_skills.mixins.json"
 	],
-	"depends": {
-		"fabricloader": ">=0.14.21",
-		"fabric-api": "*",
-		"minecraft": "~1.20",
-		"java": ">=17"
-	}
+        "depends": {
+                "fabricloader": ">=0.14.21",
+                "fabric-api": "*",
+                "minecraft": "~1.20",
+                "java": ">=17",
+                "puffish_skills": "*"
+        }
 }

--- a/Forge/build.gradle.kts
+++ b/Forge/build.gradle.kts
@@ -9,6 +9,10 @@ group = "${project.properties["maven_group"]}"
 
 evaluationDependsOn(":Common")
 
+repositories {
+        maven("https://maven.puffish.net")
+}
+
 java {
 	sourceCompatibility = JavaVersion.VERSION_17
 	targetCompatibility = JavaVersion.VERSION_17
@@ -16,11 +20,13 @@ java {
 
 dependencies {
 	minecraft("com.mojang:minecraft:${project.properties["minecraft_version"]}")
-	mappings("net.fabricmc:yarn:${project.properties["yarn_mappings"]}:v2")
+        mappings("net.fabricmc:yarn:${project.properties["yarn_mappings"]}:v2")
 
-	forge("net.minecraftforge:forge:${project.properties["minecraft_version"]}-${project.properties["forge_version"]}")
+        forge("net.minecraftforge:forge:${project.properties["minecraft_version"]}-${project.properties["forge_version"]}")
 
-	implementation(project(path = ":Common", configuration = "namedElements"))
+        modImplementation("net.puffish:skillsmod:${project.properties["skillsmod_version"]}:forge")
+
+        implementation(project(path = ":Common", configuration = "namedElements"))
 }
 
 loom {

--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -22,3 +22,10 @@ mandatory=true
 versionRange="[1.20,1.21)"
 ordering="NONE"
 side="BOTH"
+
+[[dependencies.puffish_skills]]
+modId="puffish_skills"
+mandatory=true
+versionRange="[0,)"
+ordering="NONE"
+side="BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@ archives_base_name = puffish_skills
 mixin_version = 0.12.4+mixin.0.8.5
 junit_version = 5.7.1
 fabric_loader_version=0.14.21
+
+skillsmod_version = 0.16.0+1.20


### PR DESCRIPTION
## Summary
- add Pufferfish Maven repository and Skills mod dependency to build scripts
- declare Skills mod requirement in Fabric and Forge metadata

## Testing
- `./gradlew build --console=plain`
- `./gradlew test --console=plain`
- `./gradlew check --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_689434dcb3c88327b7fc81386932f45d