### PR TITLE
refactor: delegate json object behavior

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/impl/json/ForwardingJsonObject.java
+++ b/Common/src/main/java/net/puffish/skillsmod/impl/json/ForwardingJsonObject.java
@@ -1,0 +1,92 @@
+package net.puffish.skillsmod.impl.json;
+
+import net.puffish.skillsmod.api.json.JsonArray;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.json.JsonPath;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class ForwardingJsonObject implements JsonObject {
+    protected final JsonObject parent;
+
+    public ForwardingJsonObject(JsonObject parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public Result<JsonElement, Problem> get(String key) {
+        return parent.get(key);
+    }
+
+    @Override
+    public Result<JsonObject, Problem> getObject(String key) {
+        return parent.getObject(key);
+    }
+
+    @Override
+    public Result<JsonArray, Problem> getArray(String key) {
+        return parent.getArray(key);
+    }
+
+    @Override
+    public Result<String, Problem> getString(String key) {
+        return parent.getString(key);
+    }
+
+    @Override
+    public Result<Float, Problem> getFloat(String key) {
+        return parent.getFloat(key);
+    }
+
+    @Override
+    public Result<Double, Problem> getDouble(String key) {
+        return parent.getDouble(key);
+    }
+
+    @Override
+    public Result<Integer, Problem> getInt(String key) {
+        return parent.getInt(key);
+    }
+
+    @Override
+    public Result<Boolean, Problem> getBoolean(String key) {
+        return parent.getBoolean(key);
+    }
+
+    @Override
+    public Stream<Map.Entry<String, JsonElement>> stream() {
+        return parent.stream();
+    }
+
+    @Override
+    public JsonElement getAsElement() {
+        return parent.getAsElement();
+    }
+
+    @Override
+    public <S, F> Result<Map<String, S>, Map<String, F>> getAsMap(BiFunction<String, JsonElement, Result<S, F>> function) {
+        return parent.getAsMap(function);
+    }
+
+    @Override
+    public <S> Result<S, Problem> noUnused(Function<JsonObject, Result<S, Problem>> function) {
+        return parent.noUnused(function);
+    }
+
+    @Override
+    public JsonPath getPath() {
+        return parent.getPath();
+    }
+
+    @Override
+    public com.google.gson.JsonObject getJson() {
+        return parent.getJson();
+    }
+}
+

--- a/Common/src/main/java/net/puffish/skillsmod/impl/json/JsonObjectTrackingImpl.java
+++ b/Common/src/main/java/net/puffish/skillsmod/impl/json/JsonObjectTrackingImpl.java
@@ -3,26 +3,19 @@ package net.puffish.skillsmod.impl.json;
 import net.puffish.skillsmod.api.json.JsonArray;
 import net.puffish.skillsmod.api.json.JsonElement;
 import net.puffish.skillsmod.api.json.JsonObject;
-import net.puffish.skillsmod.api.json.JsonPath;
 import net.puffish.skillsmod.api.util.Problem;
 import net.puffish.skillsmod.api.util.Result;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
-public class JsonObjectTrackingImpl implements JsonObject {
-	private final Set<String> usedKeys = new HashSet<>();
+public class JsonObjectTrackingImpl extends ForwardingJsonObject {
+        private final Set<String> usedKeys = new HashSet<>();
 
-	private final JsonObject parent;
-
-	public JsonObjectTrackingImpl(JsonObject parent) {
-		this.parent = parent;
-	}
+        public JsonObjectTrackingImpl(JsonObject parent) {
+                super(parent);
+        }
 
 	public List<Problem> reportUnusedEntries() {
 		return parent.stream()
@@ -31,81 +24,51 @@ public class JsonObjectTrackingImpl implements JsonObject {
 				.toList();
 	}
 
-	@Override
-	public Result<JsonElement, Problem> get(String key) {
-		usedKeys.add(key);
-		return parent.get(key);
-	}
+        @Override
+        public Result<JsonElement, Problem> get(String key) {
+                usedKeys.add(key);
+                return super.get(key);
+        }
 
-	@Override
-	public Result<JsonObject, Problem> getObject(String key) {
-		usedKeys.add(key);
-		return parent.getObject(key);
-	}
+        @Override
+        public Result<JsonObject, Problem> getObject(String key) {
+                usedKeys.add(key);
+                return super.getObject(key);
+        }
 
-	@Override
-	public Result<JsonArray, Problem> getArray(String key) {
-		usedKeys.add(key);
-		return parent.getArray(key);
-	}
+        @Override
+        public Result<JsonArray, Problem> getArray(String key) {
+                usedKeys.add(key);
+                return super.getArray(key);
+        }
 
-	@Override
-	public Result<String, Problem> getString(String key) {
-		usedKeys.add(key);
-		return parent.getString(key);
-	}
+        @Override
+        public Result<String, Problem> getString(String key) {
+                usedKeys.add(key);
+                return super.getString(key);
+        }
 
-	@Override
-	public Result<Float, Problem> getFloat(String key) {
-		usedKeys.add(key);
-		return parent.getFloat(key);
-	}
+        @Override
+        public Result<Float, Problem> getFloat(String key) {
+                usedKeys.add(key);
+                return super.getFloat(key);
+        }
 
-	@Override
-	public Result<Double, Problem> getDouble(String key) {
-		usedKeys.add(key);
-		return parent.getDouble(key);
-	}
+        @Override
+        public Result<Double, Problem> getDouble(String key) {
+                usedKeys.add(key);
+                return super.getDouble(key);
+        }
 
-	@Override
-	public Result<Integer, Problem> getInt(String key) {
-		usedKeys.add(key);
-		return parent.getInt(key);
-	}
+        @Override
+        public Result<Integer, Problem> getInt(String key) {
+                usedKeys.add(key);
+                return super.getInt(key);
+        }
 
-	@Override
-	public Result<Boolean, Problem> getBoolean(String key) {
-		usedKeys.add(key);
-		return parent.getBoolean(key);
-	}
-
-	@Override
-	public Stream<Map.Entry<String, JsonElement>> stream() {
-		return parent.stream();
-	}
-
-	@Override
-	public JsonElement getAsElement() {
-		return parent.getAsElement();
-	}
-
-	@Override
-	public <S, F> Result<Map<String, S>, Map<String, F>> getAsMap(BiFunction<String, JsonElement, Result<S, F>> function) {
-		return parent.getAsMap(function);
-	}
-
-	@Override
-	public <S> Result<S, Problem> noUnused(Function<JsonObject, Result<S, Problem>> function) {
-		return parent.noUnused(function);
-	}
-
-	@Override
-	public JsonPath getPath() {
-		return parent.getPath();
-	}
-
-	@Override
-	public com.google.gson.JsonObject getJson() {
-		return parent.getJson();
-	}
+        @Override
+        public Result<Boolean, Problem> getBoolean(String key) {
+                usedKeys.add(key);
+                return super.getBoolean(key);
+        }
 }


### PR DESCRIPTION
## Summary
- extract ForwardingJsonObject to centralize JsonObject delegation
- extend JsonObjectTrackingImpl from the new class and keep only key-tracking overrides

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68944b913dc08327af273f7dc7205f87