### PR TITLE
Add server command reward via composition

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/reward/BuiltinRewards.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/BuiltinRewards.java
@@ -4,13 +4,15 @@ import net.puffish.skillsmod.reward.builtin.AttributeReward;
 import net.puffish.skillsmod.reward.builtin.CommandReward;
 import net.puffish.skillsmod.reward.builtin.PointsReward;
 import net.puffish.skillsmod.reward.builtin.ScoreboardReward;
+import net.puffish.skillsmod.reward.builtin.ServerCommandReward;
 import net.puffish.skillsmod.reward.builtin.TagReward;
 import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
 
 public class BuiltinRewards {
 	public static void register() {
 		AttributeReward.register();
-		CommandReward.register();
+                CommandReward.register();
+                ServerCommandReward.register();
 		PointsReward.register();
 		ScoreboardReward.register();
 		TagReward.register();

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/CommandReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/CommandReward.java
@@ -21,85 +21,96 @@ import java.util.Objects;
 import java.util.UUID;
 
 public class CommandReward implements Reward {
-	public static final Identifier ID = SkillsMod.createIdentifier("command");
+        public static final Identifier ID = SkillsMod.createIdentifier("command");
 
-	private final Map<UUID, Integer> counts = new HashMap<>();
+        @FunctionalInterface
+        public interface Executor {
+                void execute(ServerPlayerEntity player, String command);
+        }
 
-	private final String command;
-	private final String unlockCommand;
-	private final String lockCommand;
+        private final Map<UUID, Integer> counts = new HashMap<>();
 
-	private CommandReward(String command, String unlockCommand, String lockCommand) {
-		this.command = command;
-		this.unlockCommand = unlockCommand;
-		this.lockCommand = lockCommand;
-	}
+        private final String command;
+        private final String unlockCommand;
+        private final String lockCommand;
+        private final Executor executor;
 
-	public static void register() {
-		SkillsAPI.registerReward(
-				ID,
-				CommandReward::parse
-		);
-	}
+        private CommandReward(String command, String unlockCommand, String lockCommand, Executor executor) {
+                this.command = command;
+                this.unlockCommand = unlockCommand;
+                this.lockCommand = lockCommand;
+                this.executor = executor;
+        }
 
-	private static Result<CommandReward, Problem> parse(RewardConfigContext context) {
-		return context.getData()
-				.andThen(JsonElement::getAsObject)
-				.andThen(LegacyUtils.wrapNoUnused(CommandReward::parse, context));
-	}
+        public static void register() {
+                SkillsAPI.registerReward(
+                                ID,
+                                context -> parse(context, CommandReward::executeAsPlayer)
+                );
+        }
 
-	private static Result<CommandReward, Problem> parse(JsonObject rootObject) {
-		var problems = new ArrayList<Problem>();
+        public static Result<CommandReward, Problem> parse(RewardConfigContext context, Executor executor) {
+                return context.getData()
+                                .andThen(JsonElement::getAsObject)
+                                .andThen(LegacyUtils.wrapNoUnused(obj -> parse(obj, executor), context));
+        }
 
-		var command = rootObject.get("command")
-				.getSuccess() // ignore failure because this property is optional
-				.flatMap(jsonElement -> jsonElement.getAsString()
-						.ifFailure(problems::add)
-						.getSuccess()
-				)
-				.orElse("");
+        private static Result<CommandReward, Problem> parse(JsonObject rootObject, Executor executor) {
+                var problems = new ArrayList<Problem>();
 
-		var unlockCommand = rootObject.get("unlock_command")
-				.getSuccess() // ignore failure because this property is optional
-				.flatMap(jsonElement -> jsonElement.getAsString()
-						.ifFailure(problems::add)
-						.getSuccess()
-				)
-				.orElse("");
+                var command = rootObject.get("command")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(jsonElement -> jsonElement.getAsString()
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElse("");
 
-		var lockCommand = rootObject.get("lock_command")
-				.getSuccess() // ignore failure because this property is optional
-				.flatMap(jsonElement -> jsonElement.getAsString()
-						.ifFailure(problems::add)
-						.getSuccess()
-				)
-				.orElse("");
+                var unlockCommand = rootObject.get("unlock_command")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(jsonElement -> jsonElement.getAsString()
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElse("");
 
-		if (problems.isEmpty()) {
-			return Result.success(new CommandReward(
-					command,
-					unlockCommand,
-					lockCommand
-			));
-		} else {
-			return Result.failure(Problem.combine(problems));
-		}
-	}
+                var lockCommand = rootObject.get("lock_command")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(jsonElement -> jsonElement.getAsString()
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElse("");
 
-	private void executeCommand(ServerPlayerEntity player, String command) {
-		if (command.isBlank()) {
-			return;
-		}
+                if (problems.isEmpty()) {
+                        return Result.success(new CommandReward(
+                                        command,
+                                        unlockCommand,
+                                        lockCommand,
+                                        executor
+                        ));
+                } else {
+                        return Result.failure(Problem.combine(problems));
+                }
+        }
 
-		var server = Objects.requireNonNull(player.getServer());
+        private static void executeAsPlayer(ServerPlayerEntity player, String command) {
+                var server = Objects.requireNonNull(player.getServer());
 
-		server.getCommandManager().executeWithPrefix(
-				player.getCommandSource()
-						.withSilent()
-						.withLevel(server.getFunctionPermissionLevel()),
-				command
-		);
-	}
+                server.getCommandManager().executeWithPrefix(
+                                player.getCommandSource()
+                                                .withSilent()
+                                                .withLevel(server.getFunctionPermissionLevel()),
+                                command
+                );
+        }
+
+        private void executeCommand(ServerPlayerEntity player, String command) {
+                if (command.isBlank()) {
+                        return;
+                }
+                executor.execute(player, command);
+        }
 
 	@Override
 	public void update(RewardUpdateContext context) {

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/ServerCommandReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/ServerCommandReward.java
@@ -1,0 +1,48 @@
+package net.puffish.skillsmod.reward.builtin;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.reward.Reward;
+import net.puffish.skillsmod.api.reward.RewardDisposeContext;
+import net.puffish.skillsmod.api.reward.RewardUpdateContext;
+
+import java.util.Objects;
+
+public class ServerCommandReward implements Reward {
+    public static final Identifier ID = SkillsMod.createIdentifier("server_command");
+
+    private final CommandReward delegate;
+
+    private ServerCommandReward(CommandReward delegate) {
+        this.delegate = delegate;
+    }
+
+    public static void register() {
+        SkillsAPI.registerReward(ID, context ->
+                CommandReward.parse(context, ServerCommandReward::executeAsServer)
+                        .mapSuccess(ServerCommandReward::new)
+        );
+    }
+
+    private static void executeAsServer(ServerPlayerEntity player, String command) {
+        var server = Objects.requireNonNull(player.getServer());
+        server.getCommandManager().executeWithPrefix(
+                server.getCommandSource()
+                        .withSilent()
+                        .withLevel(server.getFunctionPermissionLevel()),
+                command
+        );
+    }
+
+    @Override
+    public void update(RewardUpdateContext context) {
+        delegate.update(context);
+    }
+
+    @Override
+    public void dispose(RewardDisposeContext context) {
+        delegate.dispose(context);
+    }
+}


### PR DESCRIPTION
## Summary
- allow CommandReward to accept a command executor
- add ServerCommandReward using CommandReward internally
- register new reward in BuiltinRewards

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68944b8f5f0c8327810e5b3c02621ca6