### PR TITLE
Simplify per-level reward handling

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -765,13 +765,11 @@ public class SkillsMod {
                 for (var reward : definition.rewards()) {
                     var inst = reward.instance();
                     if (inst instanceof PerLevelRewardsReward plr) {
-                        if (plr.getSkillId() == null || plr.getSkillId().equals(skill.id())) {
-                            int newLevel = Math.min(count, plr.getMaxLevel());
-                            int oldLevel = Math.min(prev, plr.getMaxLevel());
-                            int diff = newLevel - oldLevel;
-                            if (diff != 0 && plr.getPointsPerLevel() > 0) {
-                                addPoints(player, category, categoryData, PointSources.LEVEL_REWARDS, -plr.getPointsPerLevel() * diff, true);
-                            }
+                        int newLevel = Math.min(count, plr.getMaxLevel());
+                        int oldLevel = Math.min(prev, plr.getMaxLevel());
+                        int diff = newLevel - oldLevel;
+                        if (diff != 0 && plr.getPointsPerLevel() > 0) {
+                            addPoints(player, category, categoryData, PointSources.LEVEL_REWARDS, -plr.getPointsPerLevel() * diff, true);
                         }
                     }
                 }

--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
@@ -177,7 +177,6 @@ public record SkillDefinitionConfig(
                                .map(SkillRewardConfig::instance)
                                .filter(PerLevelRewardsReward.class::isInstance)
                                .map(PerLevelRewardsReward.class::cast)
-                               .filter(reward -> reward.getSkillId() == null || reward.getSkillId().equals(id))
                                .mapToInt(PerLevelRewardsReward::getMaxLevel)
                                .max()
                                .orElse(1);

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsReward.java
@@ -21,27 +21,20 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 public class PerLevelRewardsReward implements Reward {
 	public static final Identifier ID = SkillsMod.createIdentifier("per_level_rewards");
 
     private final Map<Integer, List<SkillRewardConfig>> levelRewards;
-    private final String skillId;
     private final int maxLevel;
     private final int pointsPerLevel;
     private final Map<UUID, Integer> counts = new HashMap<>();
 
-    private PerLevelRewardsReward(Map<Integer, List<SkillRewardConfig>> levelRewards, String skillId, int maxLevel, int pointsPerLevel) {
+    private PerLevelRewardsReward(Map<Integer, List<SkillRewardConfig>> levelRewards, int maxLevel, int pointsPerLevel) {
         this.levelRewards = levelRewards;
-        this.skillId = skillId;
         this.maxLevel = maxLevel;
         this.pointsPerLevel = pointsPerLevel;
-    }
-
-    public String getSkillId() {
-        return skillId;
     }
 
     public int getMaxLevel() {
@@ -89,10 +82,6 @@ public class PerLevelRewardsReward implements Reward {
         int definedMaxLevel = levelRewards.keySet().stream().max(Integer::compareTo).orElse(0);
 
         // Access optional fields and validate values
-        var optSkillId = rootObject.getString("skill_id")
-                .ifFailure(problems::add)
-                .getSuccess();
-
         var optMaxLevelTmp = rootObject.get("max_skill_level")
                 .getSuccess()
                 .flatMap(element -> element.getAsInt()
@@ -120,7 +109,6 @@ public class PerLevelRewardsReward implements Reward {
 
         if (problems.isEmpty()) {
             return Result.success(new PerLevelRewardsReward(levelRewards,
-                            optSkillId.orElse(null),
                             optMaxLevelTmp.orElse(Math.max(1, definedMaxLevel)),
                             optPointsPerLevel));
         } else {

--- a/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
@@ -105,9 +105,7 @@ public class CategoryData {
                for (var reward : definition.rewards()) {
                        var inst = reward.instance();
                        if (inst instanceof PerLevelRewardsReward plr) {
-                               if (plr.getSkillId() == null || plr.getSkillId().equals(skill.id())) {
-                                       maxLevels = Math.max(maxLevels, plr.getMaxLevel());
-                               }
+                               maxLevels = Math.max(maxLevels, plr.getMaxLevel());
                        }
                }
 
@@ -152,9 +150,7 @@ public class CategoryData {
                 for (var reward : definition.rewards()) {
                         var inst = reward.instance();
                         if (inst instanceof PerLevelRewardsReward plr) {
-                                if (plr.getSkillId() == null || plr.getSkillId().equals(skill.id())) {
-                                        cost = Math.max(cost, plr.getPointsPerLevel());
-                                }
+                                cost = Math.max(cost, plr.getPointsPerLevel());
                         }
                 }
 

--- a/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
@@ -39,7 +39,6 @@ public class SkillDefinitionConfigTest {
     {
       \"type\": \"puffish_skill_leveling:per_level_rewards\",
       \"data\": {
-        \"skill_id\": \"skill\",
         \"levels\": { \"1\": [], \"2\": [], \"3\": [] }
       }
     }
@@ -63,7 +62,6 @@ public class SkillDefinitionConfigTest {
     {
       \"type\": \"puffish_skill_leveling:per_level_rewards\",
       \"data\": {
-        \"skill_id\": \"skill\",
         \"max_skill_level\": 3,
         \"levels\": { \"1\": [], \"2\": [], \"3\": [] }
       }

--- a/Common/src/test/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsRewardTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/reward/builtin/PerLevelRewardsRewardTest.java
@@ -42,31 +42,31 @@ public class PerLevelRewardsRewardTest {
 
         @Test
         public void testValidValues() {
-            String json = "{\"skill_id\":\"s\",\"max_skill_level\":1,\"points_per_level\":0,\"levels\":{\"1\":[]}}";
+            String json = "{\"max_skill_level\":1,\"points_per_level\":0,\"levels\":{\"1\":[]}}";
             var result = parse(json);
             Assertions.assertEquals(1, result.getSuccess().orElseThrow().getMaxLevel());
         }
 
         @Test
         public void testLevelsInferMaxLevel() {
-            String json = "{\"skill_id\":\"s\",\"levels\":{\"1\":[],\"2\":[]}}";
+            String json = "{\"levels\":{\"1\":[],\"2\":[]}}";
             var result = parse(json);
             var reward = result.getSuccess().orElseThrow();
             Assertions.assertEquals(2, reward.getMaxLevel());
             Assertions.assertEquals(0, reward.getPointsPerLevel());
         }
 
-	@Test
-	public void testInvalidMaxLevel() {
-            String json = "{\"skill_id\":\"s\",\"max_skill_level\":0,\"points_per_level\":0,\"levels\":{\"1\":[]}}";
-	    var result = parse(json);
-	    Assertions.assertTrue(result.getFailure().isPresent());
-	}
+        @Test
+        public void testInvalidMaxLevel() {
+            String json = "{\"max_skill_level\":0,\"points_per_level\":0,\"levels\":{\"1\":[]}}";
+            var result = parse(json);
+            Assertions.assertTrue(result.getFailure().isPresent());
+        }
 
-	@Test
-	public void testInvalidPointsPerLevel() {
-            String json = "{\"skill_id\":\"s\",\"max_skill_level\":1,\"points_per_level\":-1,\"levels\":{\"1\":[]}}";
-	    var result = parse(json);
-	    Assertions.assertTrue(result.getFailure().isPresent());
-	}
+        @Test
+        public void testInvalidPointsPerLevel() {
+            String json = "{\"max_skill_level\":1,\"points_per_level\":-1,\"levels\":{\"1\":[]}}";
+            var result = parse(json);
+            Assertions.assertTrue(result.getFailure().isPresent());
+        }
 }

--- a/Common/src/test/java/net/puffish/skillsmod/server/data/CategoryDataTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/server/data/CategoryDataTest.java
@@ -33,9 +33,9 @@ public class CategoryDataTest {
     @Test
     public void testPerLevelRewardExtendsMaxLevel() throws Exception {
         Map<Integer, List<SkillRewardConfig>> levelRewards = new HashMap<>();
-        Constructor<PerLevelRewardsReward> ctor = PerLevelRewardsReward.class.getDeclaredConstructor(Map.class, String.class, int.class, int.class);
+        Constructor<PerLevelRewardsReward> ctor = PerLevelRewardsReward.class.getDeclaredConstructor(Map.class, int.class, int.class);
         ctor.setAccessible(true);
-        PerLevelRewardsReward plr = ctor.newInstance(levelRewards, "skill", 3, 0);
+        PerLevelRewardsReward plr = ctor.newInstance(levelRewards, 3, 0);
         SkillRewardConfig rewardConfig = new SkillRewardConfig(PerLevelRewardsReward.ID, plr);
 
         SkillDefinitionConfig definition = new SkillDefinitionConfig(
@@ -90,9 +90,9 @@ public class CategoryDataTest {
     @Test
     public void testPerLevelRewardCostsPointsPerLevel() throws Exception {
         Map<Integer, List<SkillRewardConfig>> levelRewards = new HashMap<>();
-        Constructor<PerLevelRewardsReward> ctor = PerLevelRewardsReward.class.getDeclaredConstructor(Map.class, String.class, int.class, int.class);
+        Constructor<PerLevelRewardsReward> ctor = PerLevelRewardsReward.class.getDeclaredConstructor(Map.class, int.class, int.class);
         ctor.setAccessible(true);
-        PerLevelRewardsReward plr = ctor.newInstance(levelRewards, "skill", 1, 2);
+        PerLevelRewardsReward plr = ctor.newInstance(levelRewards, 1, 2);
         SkillRewardConfig rewardConfig = new SkillRewardConfig(PerLevelRewardsReward.ID, plr);
 
         SkillDefinitionConfig definition = new SkillDefinitionConfig(


### PR DESCRIPTION
## Summary
- drop `skill_id` from per-level reward configuration
- compute max level and costs directly from per-level rewards
- update reward point refunds to rely solely on per-level reward data

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68944b95b9a483279975b87b525e9839