### PR TITLE
Add task reflection template and docs directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,3 +149,16 @@ When refactoring this repository to rely on the external `skillsmod` library whi
 3. Rename the mod ID to `puffish_skill_leveling` and move source files and resources to the `net.bluelotuscoding.puffishskillleveling` namespace.
 4. Update affected classes to extend or wrap the official `skillsmod` classes using the new names to avoid conflicts with the base mod.
 5. Run `./gradlew :Forge:runClient` and inspect the produced jar to confirm that no `net/puffish/skillsmod` implementation packages remain and the client starts without `ResolutionException`.
+
+## Task Reflection Template
+
+Store task reflection notes in [docs/reflections/](docs/reflections/) using the following template:
+
+```
+Goal:
+Outcome:
+What went well:
+What went wrong:
+Improvements:
+```
+

--- a/docs/reflections/README.md
+++ b/docs/reflections/README.md
@@ -1,0 +1,4 @@
+# Task Reflections
+
+Store per-task reflection notes in this directory using the template outlined in [AGENTS.md](../../AGENTS.md).
+


### PR DESCRIPTION
## Summary
- Append Task Reflection Template to AGENTS.md with fields for goal, outcome, successes, issues, and improvements.
- Add docs/reflections directory with README for storing per-task reflections.

## Testing
- `./gradlew check` *(fails: cannot find symbol KeyBinding and others)*

------
https://chatgpt.com/codex/tasks/task_e_6894a92c203883279f14d9a70d20d9bc