### PR TITLE
docs: add refactoring workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - After completing tasks, record new insights in this guide so it continually improves.
 - Evaluate each task by noting successes and mistakes to refine future workflows.
 - When responding to requests, provide 10 improvement suggestions highlighting flaws and practical solutions for the project.
+- When tackling large-scale tasks, split them into independent subtasks that can run concurrently without causing merge conflicts.
 
 This document summarizes best practices for automating Minecraft mod development across Fabric, Forge, and common toolchains.
 
@@ -174,7 +175,14 @@ When turning a substantial fork into a lean addon that depends on an upstream mo
 - After each task, note what went well and what could be improved. Update this guide with any new insights.
 - Continuously refine workflows so future tasks are executed more efficiently.
 - Maintain an internal log of lessons learned and share them through code comments or documentation.
-- 
+
+## Large-Scale Refactoring Workflow
+1. Generate or update `docs/fork_audit.csv` with `git diff --name-status upstream/1.20...HEAD` to classify files as added, modified, or deleted.
+2. Verify "unchanged" files by inspecting commit history and removing any misclassified entries from the audit.
+3. Break the refactor into smaller tasks so work on new features, tests, and documentation can proceed in parallel.
+4. After each subtask, re-run builds and tests and regenerate the fork audit to keep the log accurate.
+5. Document lessons learned in `docs/reflections/` and update this guide to refine future workflows.
+
 ## Fork Audit
 Track deviations from the upstream repository with `docs/fork_audit.csv`. Regenerate it after syncing with upstream using:
 ```

--- a/docs/fork_audit.csv
+++ b/docs/fork_audit.csv
@@ -71,6 +71,9 @@ M	Forge/src/main/java/net/puffish/skillsmod/main/ForgeClientMain.java
 M	Forge/src/main/resources/META-INF/mods.toml
 A	README.md
 M	config/checkstyle/checkstyle.xml
+A	docs/fork_audit.csv
+A	docs/reflections/README.md
+A	docs/reflections/fork_audit_update.md
 A	example-skill-level-template_new.zip
 M	gradle.properties
 A	tool-versions.txt

--- a/docs/reflections/fork_audit_update.md
+++ b/docs/reflections/fork_audit_update.md
@@ -1,0 +1,5 @@
+Goal: Ensure fork audit accurately tracks added, modified, and removed files and improve guidelines for large refactors.
+Outcome: Regenerated `docs/fork_audit.csv`, confirmed unchanged files via upstream diff, and expanded `AGENTS.md` with parallel-task guidance and a refactoring workflow.
+What went well: Adding the upstream remote allowed precise comparison, and regenerating the audit caught misclassified files.
+What went wrong: Initial lists mixed unchanged classes with modified ones, leading to confusion until commit history was checked.
+Improvements: Always fetch upstream before auditing, break big refactors into smaller parallel tasks, and document lessons in reflections and AGENTS.md.


### PR DESCRIPTION
## Summary
- clarify core principles about splitting large tasks into parallel subtasks
- document a workflow for large-scale refactors and capture lessons in reflections
- regenerate `docs/fork_audit.csv` against upstream/1.20

## Testing
- `./gradlew test` *(fails: KeyBinding, ClientEventReceiver, KeyBindingReceiver, HideCategoryInPacket classes not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a8b4d7a48327b18d4fffb4dc3d10