### PR TITLE
Add skillsmod dependency to Common module

### DIFF
--- a/Common/build.gradle.kts
+++ b/Common/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     // Provide EnvType and other loader classes used by the mapped Mojang sources
     compileOnly("net.fabricmc:fabric-loader:${project.properties["fabric_loader_version"]}")
 
+    modImplementation("net.puffish:skillsmod:${project.properties["skillsmod_version"]}")
+
     testImplementation("org.junit.jupiter:junit-jupiter:${project.properties["junit_version"]}")
 }
 


### PR DESCRIPTION
## Summary
- depend on `net.puffish:skillsmod` in Common's build script
- build Common module to ensure compilation

## Testing
- `./gradlew :Common:build`

------
https://chatgpt.com/codex/tasks/task_e_6897864d1aec8327b3d20e5bd1786eff