### PR TITLE
docs: clarify SkillsMod bundling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,3 +199,6 @@ What went well:
 What went wrong:
 Improvements:
 ```
+
+## New Insights
+- Use `modImplementation` for required mod dependencies like SkillsMod so the Fabric and Forge jars bundle them. Verify with `./gradlew :Fabric:build` and `./gradlew :Forge:build` and inspect the jars to ensure inclusion.


### PR DESCRIPTION
## Summary
- document using `modImplementation` so SkillsMod is bundled in Fabric and Forge jars

## Testing
- `./gradlew :Fabric:build`
- `./gradlew :Forge:build`


------
https://chatgpt.com/codex/tasks/task_e_6897864eb92883278a295513ef30965a