### PR TITLE
Update mod identifiers and project name

### DIFF
--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -1,8 +1,8 @@
 {
 	"schemaVersion": 1,
-        "id": "puffish_skill_leveling",
-	"version": "${version}",
-	"name": "Pufferfish's Skills",
+        "id": "puffish_skill_leveling_agent",
+        "version": "${version}",
+        "name": "Pufferfish Skill Leveling",
 	"description": "Adds a fully configurable skill system to the game.",
 	"authors": [
 		"Pufferfish"

--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -3,20 +3,20 @@ loaderVersion="[46,)"
 license="All Rights Reserved"
 
 [[mods]]
-modId="puffish_skill_leveling"
+modId="puffish_skill_leveling_agent"
 version="${version}"
-displayName="Pufferfish's Skills"
+displayName="Pufferfish Skill Leveling"
 authors="Pufferfish"
 description="Adds a fully configurable skill system to the game."
 
-[[dependencies.puffish_skill_leveling]]
+[[dependencies.puffish_skill_leveling_agent]]
 modId="forge"
 mandatory=true
 versionRange="[46,)"
 ordering="NONE"
 side="BOTH"
 
-[[dependencies.puffish_skill_leveling]]
+[[dependencies.puffish_skill_leveling_agent]]
 modId="minecraft"
 mandatory=true
 versionRange="[1.20,1.21)"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,9 @@ yarn_mappings=1.20+build.1
 
 # Mod Properties
 mod_version = 0.16.3
-maven_group = net.puffish.skillsmod
-mod_id = puffish_skill_leveling
-archives_base_name = puffish_skill_leveling
+maven_group = com.example.puffish.skilllevelingagent
+mod_id = puffish_skill_leveling_agent
+archives_base_name = puffish_skill_leveling_agent
 
 # Dependencies
 mixin_version = 0.12.4+mixin.0.8.5

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,6 @@ plugins {
     id("dev.architectury.loom") version "1.5.388" apply false
 }
 
-rootProject.name = "Pufferfish's Skills"
+rootProject.name = "Pufferfish-Skill-Leveling"
 
 include("Common", "Fabric", "Forge")


### PR DESCRIPTION
## Summary
- Rename root project to `Pufferfish-Skill-Leveling`
- Assign unique Maven group and mod identifiers
- Mirror new identifiers in Fabric and Forge metadata

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6897864f6ba0832786bfe76b1da34b06