### PR TITLE
docs: document skillsmod dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,8 @@ Track deviations from the upstream repository with `docs/fork_audit.csv`. Regene
 ```
 git diff --name-status upstream/1.20...HEAD > docs/fork_audit.csv
 
+```
+
 ## Task Reflection Template
 
 Store task reflection notes in [docs/reflections/](docs/reflections/) using the following template:
@@ -199,3 +201,6 @@ What went well:
 What went wrong:
 Improvements:
 ```
+
+## Additional Insights
+- Document external dependencies in `README.md` with minimum versions and warn that addons will not start without their base mods.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 This mod provides an API to create skill trees via datapacks. Categories and skills can unlock rewards and gain experience.
 
+## Dependencies
+
+Pufferfish Skill Leveling is an addon for the base [skillsmod](https://maven.puffish.net) mod.
+
+- Requires **skillsmod 0.16.0+1.20** or newer.
+- Download from [Modrinth](https://modrinth.com/mod/skillsmod) or include via Maven:
+
+```kotlin
+repositories {
+    maven("https://maven.puffish.net/releases")
+}
+
+dependencies {
+    modImplementation("net.puffish.skillsmod:skillsmod:0.16.0+1.20")
+}
+```
+
+This addon will not start without the base mod installed.
+
 ## Player skill definitions
 
 Skill definitions describe how a skill looks, how it unlocks, and what it grants.


### PR DESCRIPTION
## Summary
- document skillsmod minimum version and Maven coordinates in README
- note addon won't launch without base skillsmod
- record new insight in AGENTS guide

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689786520a708327bbf858e1625ba17e