### PR TITLE
Add GitHub Actions CI for Fabric and Forge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        loader: [Fabric, Forge]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build
+        run: ./gradlew :${{ matrix.loader }}:build
+      - name: Test
+        run: ./gradlew :${{ matrix.loader }}:test
+      - name: Check
+        run: ./gradlew :${{ matrix.loader }}:check

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ replay_*.log
 
 # game
 run/
+# logs
+**/logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Forge builds must rely on Mojang mappings and Forge APIs, replacing any Fabric o
 Set up a CI workflow (for example with GitHub Actions) that runs `./gradlew build`
 and `./gradlew test` on every push. This catches compilation or test failures
 early and ensures the codebase follows the Checkstyle rules.
+- The `.github/workflows/ci.yml` workflow runs `build`, `test`, and `check` for both Fabric and Forge and caches Gradle dependencies for faster verification.
 
 ## Source Control
 - Keep build outputs and IDE files out of version control by respecting `.gitignore`.

--- a/docs/reflections/ci_workflow_setup.md
+++ b/docs/reflections/ci_workflow_setup.md
@@ -1,0 +1,16 @@
+Goal:
+Set up GitHub Actions CI that builds, tests, and checks both Fabric and Forge modules with cached Gradle dependencies.
+
+Outcome:
+Workflow added under `.github/workflows/ci.yml` and repository documentation updated.
+
+What went well:
+- Created matrix workflow covering both loaders.
+- Implemented Gradle dependency caching.
+- Updated AGENTS guide with CI information.
+
+What went wrong:
+- Initial attempt at editing AGENTS.md failed due to missing `ed` utility.
+
+Improvements:
+- Use a dedicated patch tool or built-in editor for editing documentation files.


### PR DESCRIPTION
## Summary
- run build, test, and check for Fabric and Forge modules in GitHub Actions
- cache Gradle dependencies for faster CI
- document CI setup and ignore generated logs

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68978654c4c883278bc99b70aecba441