### PR TITLE
Use OptionalInt for optional versions and experience

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/client/data/ClientCategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/data/ClientCategoryData.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 public class ClientCategoryData {
 	private final ClientCategoryConfig config;
@@ -21,9 +22,9 @@ public class ClientCategoryData {
 	private int spentPoints;
 	private int earnedPoints;
 
-	private int currentLevel;
-	private int currentExperience;
-	private int requiredExperience;
+        private OptionalInt currentLevel;
+        private OptionalInt currentExperience;
+        private OptionalInt requiredExperience;
 
 	private float scale = 1;
 
@@ -38,9 +39,9 @@ public class ClientCategoryData {
                         Map<String, Integer> skillLevels,
                         int spentPoints,
                         int earnedPoints,
-                        int currentLevel,
-                        int currentExperience,
-                        int requiredExperience
+                        OptionalInt currentLevel,
+                        OptionalInt currentExperience,
+                        OptionalInt requiredExperience
         ) {
                 this.config = config;
                 this.skillStates = skillStates;
@@ -381,41 +382,41 @@ public class ClientCategoryData {
 		return Math.max(config.spentPointsLimit() - spentPoints, 0);
 	}
 
-	public int getCurrentLevel() {
-		return currentLevel;
-	}
+        public OptionalInt getCurrentLevel() {
+                return currentLevel;
+        }
 
-	public boolean hasExperience() {
-		return currentLevel >= 0;
-	}
+        public boolean hasExperience() {
+                return currentLevel.isPresent();
+        }
 
-	public void setCurrentLevel(int currentLevel) {
-		this.currentLevel = currentLevel;
-	}
+        public void setCurrentLevel(int currentLevel) {
+                this.currentLevel = OptionalInt.of(currentLevel);
+        }
 
-	public int getCurrentExperience() {
-		return currentExperience;
-	}
+        public OptionalInt getCurrentExperience() {
+                return currentExperience;
+        }
 
-	public void setCurrentExperience(int currentExperience) {
-		this.currentExperience = currentExperience;
-	}
+        public void setCurrentExperience(int currentExperience) {
+                this.currentExperience = OptionalInt.of(currentExperience);
+        }
 
-	public int getRequiredExperience() {
-		return requiredExperience;
-	}
+        public OptionalInt getRequiredExperience() {
+                return requiredExperience;
+        }
 
-	public void setRequiredExperience(int requiredExperience) {
-		this.requiredExperience = requiredExperience;
-	}
+        public void setRequiredExperience(int requiredExperience) {
+                this.requiredExperience = OptionalInt.of(requiredExperience);
+        }
 
-	public float getExperienceProgress() {
-		return ((float) currentExperience) / ((float) requiredExperience);
-	}
+        public float getExperienceProgress() {
+                return ((float) currentExperience.orElse(0)) / ((float) requiredExperience.orElse(1));
+        }
 
-	public int getExperienceToNextLevel() {
-		return requiredExperience - currentExperience;
-	}
+        public int getExperienceToNextLevel() {
+                return requiredExperience.orElse(0) - currentExperience.orElse(0);
+        }
 
 	public float getScale() {
 		return scale;

--- a/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillLevelingScreen.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/gui/SkillLevelingScreen.java
@@ -50,17 +50,20 @@ public class SkillLevelingScreen extends SkillsScreen {
             if (isInsideExperience(mouseX, mouseY, x, y)) {
                 List<OrderedText> lines = new ArrayList<>();
                 var activeCategory = activeCategoryData.getConfig();
+                var currentLevel = activeCategoryData.getCurrentLevel().orElse(0);
+                var currentExp = activeCategoryData.getCurrentExperience().orElse(0);
+                var requiredExp = activeCategoryData.getRequiredExperience().orElse(0);
                 lines.add(SkillsMod.createTranslatable(
                         "tooltip",
                         "current_level",
-                        activeCategoryData.getCurrentLevel()
+                        currentLevel
                                 + (activeCategory.levelLimit() == Integer.MAX_VALUE ? "" : "/" + activeCategory.levelLimit())
                 ).asOrderedText());
                 lines.add(SkillsMod.createTranslatable(
                         "tooltip",
                         "experience_progress",
-                        activeCategoryData.getCurrentExperience(),
-                        activeCategoryData.getRequiredExperience(),
+                        currentExp,
+                        requiredExp,
                         MathHelper.floor(activeCategoryData.getExperienceProgress() * 100f)
                 ).asOrderedText());
                 lines.add(SkillsMod.createTranslatable(

--- a/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/ShowCategoryInPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/network/packets/in/ShowCategoryInPacket.java
@@ -25,6 +25,7 @@ import net.puffish.skillsmod.network.InPacket;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.OptionalInt;
 
 public class ShowCategoryInPacket implements InPacket {
 	private final ClientCategoryData category;
@@ -76,16 +77,16 @@ public class ShowCategoryInPacket implements InPacket {
                 var spentPoints = buf.readInt();
                 var earnedPoints = buf.readInt();
 
-		var levelLimit = Integer.MAX_VALUE;
-		var currentLevel = Integer.MIN_VALUE;
-		var currentExperience = Integer.MIN_VALUE;
-		var requiredExperience = Integer.MIN_VALUE;
-		if (buf.readBoolean()) {
-			levelLimit = buf.readInt();
-			currentLevel = buf.readInt();
-			currentExperience = buf.readInt();
-			requiredExperience = buf.readInt();
-		}
+                var levelLimit = Integer.MAX_VALUE;
+                OptionalInt currentLevel = OptionalInt.empty();
+                OptionalInt currentExperience = OptionalInt.empty();
+                OptionalInt requiredExperience = OptionalInt.empty();
+                if (buf.readBoolean()) {
+                        levelLimit = buf.readInt();
+                        currentLevel = OptionalInt.of(buf.readInt());
+                        currentExperience = OptionalInt.of(buf.readInt());
+                        requiredExperience = OptionalInt.of(buf.readInt());
+                }
 
 		var category = new ClientCategoryConfig(
 				id,

--- a/Common/src/main/java/net/puffish/skillsmod/impl/calculation/operation/OperationConfigContextImpl.java
+++ b/Common/src/main/java/net/puffish/skillsmod/impl/calculation/operation/OperationConfigContextImpl.java
@@ -7,6 +7,7 @@ import net.puffish.skillsmod.api.json.JsonElement;
 import net.puffish.skillsmod.api.util.Problem;
 import net.puffish.skillsmod.api.util.Result;
 import net.puffish.skillsmod.util.VersionContext;
+import java.util.OptionalInt;
 
 public record OperationConfigContextImpl(
 		ConfigContext context,
@@ -28,11 +29,11 @@ public record OperationConfigContextImpl(
 		return maybeDataElement;
 	}
 
-	@Override
-	public int getVersion() {
-		if (context instanceof VersionContext versionContext) {
-			return versionContext.getVersion();
-		}
-		return Integer.MIN_VALUE;
-	}
+        @Override
+        public OptionalInt getVersion() {
+                if (context instanceof VersionContext versionContext) {
+                        return versionContext.getVersion();
+                }
+                return OptionalInt.empty();
+        }
 }

--- a/Common/src/main/java/net/puffish/skillsmod/impl/experience/source/ExperienceSourceConfigContextImpl.java
+++ b/Common/src/main/java/net/puffish/skillsmod/impl/experience/source/ExperienceSourceConfigContextImpl.java
@@ -7,6 +7,7 @@ import net.puffish.skillsmod.api.json.JsonElement;
 import net.puffish.skillsmod.api.util.Problem;
 import net.puffish.skillsmod.api.util.Result;
 import net.puffish.skillsmod.util.VersionContext;
+import java.util.OptionalInt;
 
 public record ExperienceSourceConfigContextImpl(
 		ConfigContext context,
@@ -28,11 +29,11 @@ public record ExperienceSourceConfigContextImpl(
 		return maybeDataElement;
 	}
 
-	@Override
-	public int getVersion() {
-		if (context instanceof VersionContext versionContext) {
-			return versionContext.getVersion();
-		}
-		return Integer.MIN_VALUE;
-	}
+        @Override
+        public OptionalInt getVersion() {
+                if (context instanceof VersionContext versionContext) {
+                        return versionContext.getVersion();
+                }
+                return OptionalInt.empty();
+        }
 }

--- a/Common/src/main/java/net/puffish/skillsmod/impl/rewards/RewardConfigContextImpl.java
+++ b/Common/src/main/java/net/puffish/skillsmod/impl/rewards/RewardConfigContextImpl.java
@@ -7,6 +7,7 @@ import net.puffish.skillsmod.api.reward.RewardConfigContext;
 import net.puffish.skillsmod.api.util.Problem;
 import net.puffish.skillsmod.api.util.Result;
 import net.puffish.skillsmod.util.VersionContext;
+import java.util.OptionalInt;
 
 public record RewardConfigContextImpl(
 		ConfigContext context,
@@ -28,11 +29,11 @@ public record RewardConfigContextImpl(
 		return maybeDataElement;
 	}
 
-	@Override
-	public int getVersion() {
-		if (context instanceof VersionContext versionContext) {
-			return versionContext.getVersion();
-		}
-		return Integer.MIN_VALUE;
-	}
+        @Override
+        public OptionalInt getVersion() {
+                if (context instanceof VersionContext versionContext) {
+                        return versionContext.getVersion();
+                }
+                return OptionalInt.empty();
+        }
 }

--- a/Common/src/main/java/net/puffish/skillsmod/util/LegacyUtils.java
+++ b/Common/src/main/java/net/puffish/skillsmod/util/LegacyUtils.java
@@ -13,12 +13,13 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class LegacyUtils {
-	public static boolean isRemoved(int removalVersion, ConfigContext context) {
-		if (context instanceof VersionContext versionContext) {
-			return versionContext.getVersion() >= removalVersion;
-		}
-		return true;
-	}
+        public static boolean isRemoved(int removalVersion, ConfigContext context) {
+                if (context instanceof VersionContext versionContext) {
+                        var opt = versionContext.getVersion();
+                        return opt.isPresent() && opt.getAsInt() >= removalVersion;
+                }
+                return true;
+        }
 
 	public static <S, F> Optional<S> deprecated(Supplier<? extends Result<S, F>> supplier, int removalVersion, ConfigContext context) {
 		if (isRemoved(removalVersion, context)) {

--- a/Common/src/main/java/net/puffish/skillsmod/util/VersionContext.java
+++ b/Common/src/main/java/net/puffish/skillsmod/util/VersionContext.java
@@ -1,5 +1,7 @@
 package net.puffish.skillsmod.util;
 
+import java.util.OptionalInt;
+
 public interface VersionContext {
-	int getVersion();
+        OptionalInt getVersion();
 }

--- a/Common/src/main/java/net/puffish/skillsmod/util/VersionedConfigContext.java
+++ b/Common/src/main/java/net/puffish/skillsmod/util/VersionedConfigContext.java
@@ -2,10 +2,11 @@ package net.puffish.skillsmod.util;
 
 import net.minecraft.server.MinecraftServer;
 import net.puffish.skillsmod.api.config.ConfigContext;
+import java.util.OptionalInt;
 
 public record VersionedConfigContext(
 		ConfigContext context,
-		int version
+                int version
 ) implements ConfigContext, VersionContext {
 
 	@Override
@@ -18,8 +19,8 @@ public record VersionedConfigContext(
 		context.emitWarning(message);
 	}
 
-	@Override
-	public int getVersion() {
-		return version;
-	}
+        @Override
+        public OptionalInt getVersion() {
+                return OptionalInt.of(version);
+        }
 }

--- a/Common/src/test/java/net/puffish/skillsmod/util/VersionContextTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/util/VersionContextTest.java
@@ -1,0 +1,79 @@
+package net.puffish.skillsmod.util;
+
+import net.minecraft.server.MinecraftServer;
+import net.puffish.skillsmod.api.config.ConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.impl.calculation.operation.OperationConfigContextImpl;
+import net.puffish.skillsmod.impl.experience.source.ExperienceSourceConfigContextImpl;
+import net.puffish.skillsmod.impl.rewards.RewardConfigContextImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VersionContextTest {
+    private static class DummyContext implements ConfigContext {
+        @Override
+        public MinecraftServer getServer() {
+            return null;
+        }
+
+        @Override
+        public void emitWarning(String message) {
+        }
+    }
+
+    private static class DummyVersionedContext extends DummyContext implements VersionContext {
+        private final OptionalInt version;
+
+        DummyVersionedContext(int version) {
+            this.version = OptionalInt.of(version);
+        }
+
+        @Override
+        public OptionalInt getVersion() {
+            return version;
+        }
+    }
+
+    private static final Result<JsonElement, Problem> DATA = Result.failure(Problem.message("no data"));
+
+    @Test
+    public void experienceSourceMissingVersion() {
+        var ctx = new ExperienceSourceConfigContextImpl(new DummyContext(), DATA);
+        assertTrue(ctx.getVersion().isEmpty());
+    }
+
+    @Test
+    public void experienceSourceWithVersion() {
+        var ctx = new ExperienceSourceConfigContextImpl(new DummyVersionedContext(5), DATA);
+        assertEquals(OptionalInt.of(5), ctx.getVersion());
+    }
+
+    @Test
+    public void rewardMissingVersion() {
+        var ctx = new RewardConfigContextImpl(new DummyContext(), DATA);
+        assertTrue(ctx.getVersion().isEmpty());
+    }
+
+    @Test
+    public void rewardWithVersion() {
+        var ctx = new RewardConfigContextImpl(new DummyVersionedContext(7), DATA);
+        assertEquals(OptionalInt.of(7), ctx.getVersion());
+    }
+
+    @Test
+    public void operationMissingVersion() {
+        var ctx = new OperationConfigContextImpl(new DummyContext(), DATA);
+        assertTrue(ctx.getVersion().isEmpty());
+    }
+
+    @Test
+    public void operationWithVersion() {
+        var ctx = new OperationConfigContextImpl(new DummyVersionedContext(9), DATA);
+        assertEquals(OptionalInt.of(9), ctx.getVersion());
+    }
+}


### PR DESCRIPTION
## Summary
- Replace sentinel version values with `OptionalInt` across config contexts
- Propagate optional experience values in client category data and UI
- Add tests for presence/absence of version information

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6897865b64b08327a4984ba24f4ae87e