### PR TITLE
Align weapon access with Skills mod API

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/access/DamageSourceAccess.java
+++ b/Common/src/main/java/net/puffish/skillsmod/access/DamageSourceAccess.java
@@ -2,8 +2,6 @@ package net.puffish.skillsmod.access;
 
 import net.minecraft.item.ItemStack;
 
-import java.util.Optional;
-
 public interface DamageSourceAccess {
-	Optional<ItemStack> getWeapon();
+        ItemStack getWeapon();
 }

--- a/Common/src/main/java/net/puffish/skillsmod/mixin/DamageSourceMixin.java
+++ b/Common/src/main/java/net/puffish/skillsmod/mixin/DamageSourceMixin.java
@@ -14,12 +14,10 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Optional;
-
 @Mixin(DamageSource.class)
 public class DamageSourceMixin implements DamageSourceAccess {
-	@Unique
-	private ItemStack weapon;
+        @Unique
+        private ItemStack weapon = ItemStack.EMPTY;
 
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void injectAtInit(RegistryEntry<DamageType> type, Entity source, Entity attacker, Vec3d position, CallbackInfo ci) {
@@ -28,9 +26,9 @@ public class DamageSourceMixin implements DamageSourceAccess {
 		}
 	}
 
-	@Override
-	@Unique
-	public Optional<ItemStack> getWeapon() {
-		return Optional.ofNullable(weapon);
-	}
+        @Override
+        @Unique
+        public ItemStack getWeapon() {
+                return weapon;
+        }
 }

--- a/Common/src/main/java/net/puffish/skillsmod/mixin/LivingEntityMixin.java
+++ b/Common/src/main/java/net/puffish/skillsmod/mixin/LivingEntityMixin.java
@@ -2,7 +2,6 @@ package net.puffish.skillsmod.mixin;
 
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.MathHelper;
 import net.puffish.skillsmod.access.DamageSourceAccess;
@@ -50,8 +49,8 @@ public abstract class LivingEntityMixin {
 
 	@Inject(method = "applyDamage", at = @At("TAIL"))
 	private void injectAtApplyDamage(DamageSource source, float damage, CallbackInfo ci) {
-		var entity = ((LivingEntity) (Object) this);
-		var weapon = ((DamageSourceAccess) source).getWeapon().orElse(ItemStack.EMPTY);
+                var entity = ((LivingEntity) (Object) this);
+                var weapon = ((DamageSourceAccess) source).getWeapon();
 
 		if (source.getAttacker() instanceof ServerPlayerEntity player) {
 			damageShare.compute(player, (key, value) -> {
@@ -82,8 +81,8 @@ public abstract class LivingEntityMixin {
 	@Inject(method = "drop", at = @At("TAIL"))
 	private void injectAtDrop(DamageSource source, CallbackInfo ci) {
 		if (source.getAttacker() instanceof ServerPlayerEntity player) {
-			var entity = ((LivingEntity) (Object) this);
-			var weapon = ((DamageSourceAccess) source).getWeapon().orElse(ItemStack.EMPTY);
+                        var entity = ((LivingEntity) (Object) this);
+                        var weapon = ((DamageSourceAccess) source).getWeapon();
 
 			var antiFarmingData = ((WorldChunkAccess) entity.getWorld()
 					.getWorldChunk(entity.getBlockPos()))

--- a/Common/src/main/java/net/puffish/skillsmod/mixin/PlayerEntityMixin.java
+++ b/Common/src/main/java/net/puffish/skillsmod/mixin/PlayerEntityMixin.java
@@ -2,7 +2,6 @@ package net.puffish.skillsmod.mixin;
 
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.puffish.skillsmod.access.DamageSourceAccess;
 import net.puffish.skillsmod.api.SkillsAPI;
@@ -23,8 +22,8 @@ public abstract class PlayerEntityMixin {
 			)
 	)
 	private void injectAtSetHealth(DamageSource source, float damage, CallbackInfo ci) {
-		if (((PlayerEntity) (Object) this) instanceof ServerPlayerEntity player) {
-			var weapon = ((DamageSourceAccess) source).getWeapon().orElse(ItemStack.EMPTY);
+                if (((PlayerEntity) (Object) this) instanceof ServerPlayerEntity player) {
+                        var weapon = ((DamageSourceAccess) source).getWeapon();
 			var takenDamage = Math.min(damage, player.getHealth());
 
 			SkillsAPI.updateExperienceSources(


### PR DESCRIPTION
## Summary
- Use direct `ItemStack` weapon stack from Skills API instead of `Optional`
- Update damage source mixin to store and expose the stack directly
- Simplify player and living entity mixins to use the direct weapon stack

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689434df6fd48327a1081ccc398d7f1c