### PR TITLE
Add extended client entrypoints for addon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,3 +199,6 @@ What went well:
 What went wrong:
 Improvements:
 ```
+
+## Insights
+- Introduced extended client bootstrap classes for Fabric and Forge, providing a central hook for addon-specific packet and configuration registration.

--- a/Common/src/main/java/net/puffish/skillsmod/client/addon/SkillLevelingAddonClient.java
+++ b/Common/src/main/java/net/puffish/skillsmod/client/addon/SkillLevelingAddonClient.java
@@ -1,0 +1,35 @@
+package net.puffish.skillsmod.client.addon;
+
+/**
+ * Handles client-side registration for the Skill Leveling addon.
+ * <p>
+ * This class provides hooks to register any additional packet handlers
+ * and configuration required by the addon without modifying the base
+ * mod's client bootstrap classes.
+ */
+public final class SkillLevelingAddonClient {
+
+    private SkillLevelingAddonClient() {
+    }
+
+    /**
+     * Registers addon specific networking and configuration.
+     *
+     * <p>Currently this method is a placeholder and performs no actions,
+     * but it allows future work to plug in custom behaviour in a single
+     * location.
+     */
+    public static void setup() {
+        registerPackets();
+        registerConfigs();
+    }
+
+    private static void registerPackets() {
+        // Addon packet handlers can be registered here in the future.
+    }
+
+    private static void registerConfigs() {
+        // Addon client configuration can be registered here in the future.
+    }
+}
+

--- a/Fabric/src/main/java/net/puffish/skillsmod/main/ExtendedFabricClientMain.java
+++ b/Fabric/src/main/java/net/puffish/skillsmod/main/ExtendedFabricClientMain.java
@@ -1,0 +1,17 @@
+package net.puffish.skillsmod.main;
+
+import net.puffish.skillsmod.client.addon.SkillLevelingAddonClient;
+
+/**
+ * Fabric entry point that extends the base client bootstrap to register
+ * additional packets and configuration required by the Skill Leveling addon.
+ */
+public class ExtendedFabricClientMain extends FabricClientMain {
+
+    @Override
+    public void onInitializeClient() {
+        super.onInitializeClient();
+        SkillLevelingAddonClient.setup();
+    }
+}
+

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -10,9 +10,9 @@
 	"license": "All Rights Reserved",
 	"environment": "*",
 	"entrypoints": {
-		"client": [
-			"net.puffish.skillsmod.main.FabricClientMain"
-		],
+                "client": [
+                        "net.puffish.skillsmod.main.ExtendedFabricClientMain"
+                ],
 		"main": [
 			"net.puffish.skillsmod.main.FabricMain"
 		]

--- a/Forge/src/main/java/net/puffish/skillsmod/main/ExtendedForgeClientMain.java
+++ b/Forge/src/main/java/net/puffish/skillsmod/main/ExtendedForgeClientMain.java
@@ -1,0 +1,16 @@
+package net.puffish.skillsmod.main;
+
+import net.puffish.skillsmod.client.addon.SkillLevelingAddonClient;
+
+/**
+ * Forge client bootstrap that builds upon the base implementation and
+ * registers extra packet handlers and configuration for the Skill Leveling addon.
+ */
+public class ExtendedForgeClientMain extends ForgeClientMain {
+
+    public ExtendedForgeClientMain() {
+        super();
+        SkillLevelingAddonClient.setup();
+    }
+}
+

--- a/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
+++ b/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
@@ -47,7 +47,7 @@ public class ForgeMain {
 	private final List<ServerEventListener> serverListeners = new ArrayList<>();
 
 	public ForgeMain() {
-		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> ForgeClientMain::new);
+                DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> ExtendedForgeClientMain::new);
 
 		var forgeEventBus = MinecraftForge.EVENT_BUS;
 		forgeEventBus.addListener(this::onPlayerLoggedIn);


### PR DESCRIPTION
## Summary
- add `SkillLevelingAddonClient` helper for addon packet & config hooks
- introduce `ExtendedFabricClientMain` and `ExtendedForgeClientMain`
- wire Fabric and Forge loaders to the new entry points

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689858cec90483279afdb114dd304810