### PR TITLE
Add extended network packets and data wrappers

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/server/data/ExtendedCategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/data/ExtendedCategoryData.java
@@ -1,0 +1,63 @@
+package net.puffish.skillsmod.server.data;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.config.GeneralConfig;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Wrapper around {@link CategoryData} used when additional information
+ * about a category needs to be transferred.  All behaviour that is not
+ * explicitly extended is delegated to the underlying {@code CategoryData}
+ * instance so existing logic remains untouched.
+ */
+public class ExtendedCategoryData {
+    private final CategoryData delegate;
+
+    private ExtendedCategoryData(CategoryData delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Creates a new extended category using the same initialisation rules as
+     * {@link CategoryData#create(GeneralConfig)}.
+     */
+    public static ExtendedCategoryData create(GeneralConfig general) {
+        return new ExtendedCategoryData(CategoryData.create(general));
+    }
+
+    /**
+     * Deserialises the category data from NBT.  The base implementation is
+     * reused and therefore backwards compatible with vanilla save data.
+     */
+    public static ExtendedCategoryData read(NbtCompound nbt) {
+        return new ExtendedCategoryData(CategoryData.read(nbt));
+    }
+
+    /**
+     * Serialises the data back into NBT by delegating to the wrapped
+     * {@link CategoryData} instance.
+     */
+    public NbtCompound writeNbt(NbtCompound nbt) {
+        return delegate.writeNbt(nbt);
+    }
+
+    /**
+     * Provides access to the underlying {@link CategoryData} for components
+     * that still operate on the original type.
+     */
+    public CategoryData asCategoryData() {
+        return delegate;
+    }
+
+    /**
+     * Returns a snapshot of the point map.  Only entries with a non-zero
+     * value are included.
+     */
+    public Map<Identifier, Integer> getPoints() {
+        return delegate.getPointsSources()
+                .collect(Collectors.toMap(id -> id, delegate::getPoints));
+    }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ExtendedShowCategoryOutPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ExtendedShowCategoryOutPacket.java
@@ -1,0 +1,41 @@
+package net.puffish.skillsmod.server.network.packets.out;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.config.CategoryConfig;
+import net.puffish.skillsmod.network.OutPacket;
+import net.puffish.skillsmod.server.data.ExtendedCategoryData;
+import net.puffish.skillsmod.util.ExtendedPointSources;
+
+import java.util.Map;
+
+/**
+ * Variant of {@link ShowCategoryOutPacket} that additionally serialises the
+ * individual point sources of a category.  All base fields are written using
+ * the original packet to retain compatibility and minimise duplication.
+ */
+public class ExtendedShowCategoryOutPacket implements OutPacket {
+    private final ShowCategoryOutPacket base;
+    private final ExtendedCategoryData data;
+
+    public ExtendedShowCategoryOutPacket(CategoryConfig category, ExtendedCategoryData data) {
+        this.base = new ShowCategoryOutPacket(category, data.asCategoryData());
+        this.data = data;
+    }
+
+    @Override
+    public void write(PacketByteBuf buf) {
+        // write existing information
+        base.write(buf);
+        // write additional point information
+        Map<Identifier, Integer> points = data.getPoints();
+        ExtendedPointSources.write(buf, points);
+    }
+
+    @Override
+    public Identifier getId() {
+        // reuse the same packet identifier; extended clients must know how
+        // to consume the additional payload.
+        return base.getId();
+    }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ExtendedSkillUpdateOutPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ExtendedSkillUpdateOutPacket.java
@@ -1,0 +1,56 @@
+package net.puffish.skillsmod.server.network.packets.out;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.network.OutPacket;
+import net.puffish.skillsmod.server.data.CategoryData;
+import net.puffish.skillsmod.config.CategoryConfig;
+import net.puffish.skillsmod.util.ExtendedPointSources;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Extended version of {@link SkillUpdateOutPacket}.  In addition to the
+ * standard information about the skill, this packet also includes the
+ * player's point totals per source after the update.  The base packet is
+ * used internally so that unchanged behaviour is delegated.
+ */
+public class ExtendedSkillUpdateOutPacket implements OutPacket {
+    private final SkillUpdateOutPacket base;
+    private final Map<Identifier, Integer> points;
+    private final int spentPoints;
+    private final int earnedPoints;
+
+    /**
+     * Creates a packet representing the change of a single skill as well as
+     * the resulting point totals.  The totals are computed from the supplied
+     * category data to ensure consistency with the server state.
+     */
+    public ExtendedSkillUpdateOutPacket(Identifier categoryId,
+                                        String skillId,
+                                        boolean unlocked,
+                                        int level,
+                                        CategoryConfig category,
+                                        CategoryData data) {
+        this.base = new SkillUpdateOutPacket(categoryId, skillId, unlocked, level);
+        this.spentPoints = data.getSpentPoints(category);
+        this.earnedPoints = data.getPointsTotal();
+        this.points = data.getPointsSources()
+                .collect(Collectors.toMap(id -> id, data::getPoints));
+    }
+
+    @Override
+    public void write(PacketByteBuf buf) {
+        base.write(buf);
+        buf.writeInt(spentPoints);
+        buf.writeInt(earnedPoints);
+        ExtendedPointSources.write(buf, points);
+    }
+
+    @Override
+    public Identifier getId() {
+        // keep using the same packet identifier as the vanilla skill update
+        return base.getId();
+    }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/util/ExtendedPointSources.java
+++ b/Common/src/main/java/net/puffish/skillsmod/util/ExtendedPointSources.java
@@ -1,0 +1,41 @@
+package net.puffish.skillsmod.util;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+
+import java.util.Map;
+
+/**
+ * Utility helpers extending {@link PointSources} with support for
+ * serialising and deserialising maps of point sources.  The class
+ * purposely contains only static methods as it merely augments the
+ * existing constants defined by {@link PointSources}.
+ */
+public final class ExtendedPointSources extends PointSources {
+    private ExtendedPointSources() {
+        // utility class
+    }
+
+    /**
+     * Writes the given map of point sources to the provided buffer.
+     * Entries with a zero value are still written to ensure the client
+     * can faithfully reconstruct the map.
+     *
+     * @param buf    target buffer
+     * @param points map of source identifier to amount
+     */
+    public static void write(PacketByteBuf buf, Map<Identifier, Integer> points) {
+        buf.writeMap(points, PacketByteBuf::writeIdentifier, PacketByteBuf::writeInt);
+    }
+
+    /**
+     * Reads a map of point sources from the buffer.  The map mirrors the
+     * structure written by {@link #write(PacketByteBuf, Map)}.
+     *
+     * @param buf source buffer
+     * @return reconstructed map of sources to amounts
+     */
+    public static Map<Identifier, Integer> read(PacketByteBuf buf) {
+        return buf.readMap(PacketByteBuf::readIdentifier, PacketByteBuf::readInt);
+    }
+}


### PR DESCRIPTION
## Summary
- add utility to serialise point source maps
- wrap CategoryData for extended point serialisation
- extend show and skill update packets to include point breakdown

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_689858cf6eac8327993aa9ca87d6b054