### PR TITLE
Add extended experience sources with modern calculation

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/BuiltinExperienceSources.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/BuiltinExperienceSources.java
@@ -1,31 +1,31 @@
 package net.puffish.skillsmod.experience.source;
 
 import net.puffish.skillsmod.experience.source.builtin.BreakBlockExperienceSource;
-import net.puffish.skillsmod.experience.source.builtin.CraftItemExperienceSource;
+import net.puffish.skillsmod.experience.source.builtin.ExtendedCraftItemExperienceSource;
 import net.puffish.skillsmod.experience.source.builtin.DealDamageExperienceSource;
-import net.puffish.skillsmod.experience.source.builtin.EatFoodExperienceSource;
+import net.puffish.skillsmod.experience.source.builtin.ExtendedEatFoodExperienceSource;
 import net.puffish.skillsmod.experience.source.builtin.EnchantItemExperienceSource;
 import net.puffish.skillsmod.experience.source.builtin.FishItemExperienceSource;
 import net.puffish.skillsmod.experience.source.builtin.HealExperienceSource;
-import net.puffish.skillsmod.experience.source.builtin.IncreaseStatExperienceSource;
-import net.puffish.skillsmod.experience.source.builtin.KillEntityExperienceSource;
-import net.puffish.skillsmod.experience.source.builtin.MineBlockExperienceSource;
+import net.puffish.skillsmod.experience.source.builtin.ExtendedIncreaseStatExperienceSource;
+import net.puffish.skillsmod.experience.source.builtin.ExtendedKillEntityExperienceSource;
+import net.puffish.skillsmod.experience.source.builtin.ExtendedMineBlockExperienceSource;
 import net.puffish.skillsmod.experience.source.builtin.SharedKillEntityExperienceSource;
-import net.puffish.skillsmod.experience.source.builtin.TakeDamageExperienceSource;
+import net.puffish.skillsmod.experience.source.builtin.ExtendedTakeDamageExperienceSource;
 
 public class BuiltinExperienceSources {
 	public static void register() {
 		BreakBlockExperienceSource.register();
-		CraftItemExperienceSource.register();
+		ExtendedCraftItemExperienceSource.register();
 		DealDamageExperienceSource.register();
-		EatFoodExperienceSource.register();
+		ExtendedEatFoodExperienceSource.register();
 		EnchantItemExperienceSource.register();
 		FishItemExperienceSource.register();
 		HealExperienceSource.register();
-		IncreaseStatExperienceSource.register();
-		KillEntityExperienceSource.register();
-		MineBlockExperienceSource.register();
+		ExtendedIncreaseStatExperienceSource.register();
+		ExtendedKillEntityExperienceSource.register();
+		ExtendedMineBlockExperienceSource.register();
 		SharedKillEntityExperienceSource.register();
-		TakeDamageExperienceSource.register();
+		ExtendedTakeDamageExperienceSource.register();
 	}
 }

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/CraftItemExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/CraftItemExperienceSource.java
@@ -24,8 +24,8 @@ import net.puffish.skillsmod.calculation.operation.builtin.ItemStackCondition;
 import net.puffish.skillsmod.calculation.operation.builtin.legacy.LegacyItemTagCondition;
 
 public class CraftItemExperienceSource implements ExperienceSource {
-	private static final Identifier ID = SkillsMod.createIdentifier("craft_item");
-	private static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+	protected static final Identifier ID = SkillsMod.createIdentifier("craft_item");
+	protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
 
 	static {
 		PROTOTYPE.registerOperation(
@@ -40,9 +40,9 @@ public class CraftItemExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private final Calculation<Data> calculation;
+	protected final Calculation<Data> calculation;
 
-	private CraftItemExperienceSource(Calculation<Data> calculation) {
+	protected CraftItemExperienceSource(Calculation<Data> calculation) {
 		this.calculation = calculation;
 	}
 
@@ -60,7 +60,7 @@ public class CraftItemExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private record Data(ServerPlayerEntity player, ItemStack itemStack) { }
+	protected record Data(ServerPlayerEntity player, ItemStack itemStack) { }
 
 	public int getValue(ServerPlayerEntity player, ItemStack itemStack) {
 		return (int) Math.round(calculation.evaluate(

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/EatFoodExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/EatFoodExperienceSource.java
@@ -24,8 +24,8 @@ import net.puffish.skillsmod.calculation.operation.builtin.ItemStackCondition;
 import net.puffish.skillsmod.calculation.operation.builtin.legacy.LegacyItemTagCondition;
 
 public class EatFoodExperienceSource implements ExperienceSource {
-	private static final Identifier ID = SkillsMod.createIdentifier("eat_food");
-	private static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+	protected static final Identifier ID = SkillsMod.createIdentifier("eat_food");
+	protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
 
 	static {
 		PROTOTYPE.registerOperation(
@@ -40,9 +40,9 @@ public class EatFoodExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private final Calculation<Data> calculation;
+	protected final Calculation<Data> calculation;
 
-	private EatFoodExperienceSource(Calculation<Data> calculation) {
+	protected EatFoodExperienceSource(Calculation<Data> calculation) {
 		this.calculation = calculation;
 	}
 
@@ -60,7 +60,7 @@ public class EatFoodExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private record Data(ServerPlayerEntity player, ItemStack itemStack) { }
+	protected record Data(ServerPlayerEntity player, ItemStack itemStack) { }
 
 	public int getValue(ServerPlayerEntity player, ItemStack itemStack) {
 		return (int) Math.round(calculation.evaluate(

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedCraftItemExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedCraftItemExperienceSource.java
@@ -1,0 +1,81 @@
+package net.puffish.skillsmod.experience.source.builtin;
+
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.calculation.Calculation;
+import net.puffish.skillsmod.api.calculation.Variables;
+import net.puffish.skillsmod.api.calculation.operation.OperationFactory;
+import net.puffish.skillsmod.api.calculation.prototype.BuiltinPrototypes;
+import net.puffish.skillsmod.api.calculation.prototype.Prototype;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import java.util.ArrayList;
+import java.util.Map;
+
+public class ExtendedCraftItemExperienceSource extends CraftItemExperienceSource {
+        protected static final Identifier ID = SkillsMod.createIdentifier("craft_item");
+        protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+
+	static {
+		PROTOTYPE.registerOperation(
+				SkillsMod.createIdentifier("get_player"),
+				BuiltinPrototypes.PLAYER,
+				OperationFactory.create(Data::player)
+		);
+		PROTOTYPE.registerOperation(
+				SkillsMod.createIdentifier("get_crafted_item_stack"),
+				BuiltinPrototypes.ITEM_STACK,
+				OperationFactory.create(Data::itemStack)
+		);
+	}
+
+        private ExtendedCraftItemExperienceSource(Calculation<Data> calculation) {
+                super(calculation);
+        }
+
+        public static void register() {
+                SkillsAPI.registerExperienceSource(
+                                ID,
+                                ExtendedCraftItemExperienceSource::parse
+                );
+        }
+
+        private static Result<ExtendedCraftItemExperienceSource, Problem> parse(ExperienceSourceConfigContext context) {
+                return context.getData()
+                                .andThen(JsonElement::getAsObject)
+                                .andThen(rootObject -> rootObject.noUnused(o -> parse(o, context)));
+        }
+
+        private static Result<ExtendedCraftItemExperienceSource, Problem> parse(JsonObject rootObject, ExperienceSourceConfigContext context) {
+                var problems = new ArrayList<Problem>();
+
+                var variables = rootObject.get("variables")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(variablesElement -> Variables.parse(variablesElement, PROTOTYPE, context)
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElseGet(() -> Variables.create(Map.of()));
+
+                var optCalculation = rootObject.get("experience")
+                                .andThen(experienceElement -> Calculation.parse(
+                                                experienceElement,
+                                                variables,
+                                                context
+                                ))
+                                .ifFailure(problems::add)
+                                .getSuccess();
+
+                if (problems.isEmpty()) {
+                        return Result.success(new ExtendedCraftItemExperienceSource(
+                                        optCalculation.orElseThrow()
+                        ));
+                } else {
+                        return Result.failure(Problem.combine(problems));
+                }
+        }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedEatFoodExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedEatFoodExperienceSource.java
@@ -1,0 +1,81 @@
+package net.puffish.skillsmod.experience.source.builtin;
+
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.calculation.Calculation;
+import net.puffish.skillsmod.api.calculation.Variables;
+import net.puffish.skillsmod.api.calculation.operation.OperationFactory;
+import net.puffish.skillsmod.api.calculation.prototype.BuiltinPrototypes;
+import net.puffish.skillsmod.api.calculation.prototype.Prototype;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import java.util.ArrayList;
+import java.util.Map;
+
+public class ExtendedEatFoodExperienceSource extends EatFoodExperienceSource {
+        protected static final Identifier ID = SkillsMod.createIdentifier("eat_food");
+        protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+
+        static {
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_player"),
+                                BuiltinPrototypes.PLAYER,
+                                OperationFactory.create(Data::player)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_eaten_item_stack"),
+                                BuiltinPrototypes.ITEM_STACK,
+                                OperationFactory.create(Data::itemStack)
+                );
+        }
+
+        private ExtendedEatFoodExperienceSource(Calculation<Data> calculation) {
+                super(calculation);
+        }
+
+        public static void register() {
+                SkillsAPI.registerExperienceSource(
+                                ID,
+                                ExtendedEatFoodExperienceSource::parse
+                );
+        }
+
+        private static Result<ExtendedEatFoodExperienceSource, Problem> parse(ExperienceSourceConfigContext context) {
+                return context.getData()
+                                .andThen(JsonElement::getAsObject)
+                                .andThen(rootObject -> rootObject.noUnused(o -> parse(o, context)));
+        }
+
+        private static Result<ExtendedEatFoodExperienceSource, Problem> parse(JsonObject rootObject, ExperienceSourceConfigContext context) {
+                var problems = new ArrayList<Problem>();
+
+                var variables = rootObject.get("variables")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(variablesElement -> Variables.parse(variablesElement, PROTOTYPE, context)
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElseGet(() -> Variables.create(Map.of()));
+
+                var optCalculation = rootObject.get("experience")
+                                .andThen(experienceElement -> Calculation.parse(
+                                                experienceElement,
+                                                variables,
+                                                context
+                                ))
+                                .ifFailure(problems::add)
+                                .getSuccess();
+
+                if (problems.isEmpty()) {
+                        return Result.success(new ExtendedEatFoodExperienceSource(
+                                        optCalculation.orElseThrow()
+                        ));
+                } else {
+                        return Result.failure(Problem.combine(problems));
+                }
+        }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedIncreaseStatExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedIncreaseStatExperienceSource.java
@@ -1,0 +1,86 @@
+package net.puffish.skillsmod.experience.source.builtin;
+
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.calculation.Calculation;
+import net.puffish.skillsmod.api.calculation.Variables;
+import net.puffish.skillsmod.api.calculation.operation.OperationFactory;
+import net.puffish.skillsmod.api.calculation.prototype.BuiltinPrototypes;
+import net.puffish.skillsmod.api.calculation.prototype.Prototype;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import java.util.ArrayList;
+import java.util.Map;
+
+public class ExtendedIncreaseStatExperienceSource extends IncreaseStatExperienceSource {
+        protected static final Identifier ID = SkillsMod.createIdentifier("increase_stat");
+        protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+
+        static {
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_player"),
+                                BuiltinPrototypes.PLAYER,
+                                OperationFactory.create(Data::player)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_stat"),
+                                BuiltinPrototypes.STAT,
+                                OperationFactory.create(Data::stat)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_increase_amount"),
+                                BuiltinPrototypes.NUMBER,
+                                OperationFactory.create(data -> (double) data.amount())
+                );
+        }
+
+        private ExtendedIncreaseStatExperienceSource(Calculation<Data> calculation) {
+                super(calculation);
+        }
+
+        public static void register() {
+                SkillsAPI.registerExperienceSource(
+                                ID,
+                                ExtendedIncreaseStatExperienceSource::parse
+                );
+        }
+
+        private static Result<ExtendedIncreaseStatExperienceSource, Problem> parse(ExperienceSourceConfigContext context) {
+                return context.getData()
+                                .andThen(JsonElement::getAsObject)
+                                .andThen(rootObject -> rootObject.noUnused(o -> parse(o, context)));
+        }
+
+        private static Result<ExtendedIncreaseStatExperienceSource, Problem> parse(JsonObject rootObject, ExperienceSourceConfigContext context) {
+                var problems = new ArrayList<Problem>();
+
+                var variables = rootObject.get("variables")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(variablesElement -> Variables.parse(variablesElement, PROTOTYPE, context)
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElseGet(() -> Variables.create(Map.of()));
+
+                var optCalculation = rootObject.get("experience")
+                                .andThen(experienceElement -> Calculation.parse(
+                                                experienceElement,
+                                                variables,
+                                                context
+                                ))
+                                .ifFailure(problems::add)
+                                .getSuccess();
+
+                if (problems.isEmpty()) {
+                        return Result.success(new ExtendedIncreaseStatExperienceSource(
+                                        optCalculation.orElseThrow()
+                        ));
+                } else {
+                        return Result.failure(Problem.combine(problems));
+                }
+        }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedKillEntityExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedKillEntityExperienceSource.java
@@ -1,0 +1,110 @@
+package net.puffish.skillsmod.experience.source.builtin;
+
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.calculation.Calculation;
+import net.puffish.skillsmod.api.calculation.Variables;
+import net.puffish.skillsmod.api.calculation.operation.OperationFactory;
+import net.puffish.skillsmod.api.calculation.prototype.BuiltinPrototypes;
+import net.puffish.skillsmod.api.calculation.prototype.Prototype;
+import net.puffish.skillsmod.api.config.ConfigContext;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.calculation.LegacyBuiltinPrototypes;
+import net.puffish.skillsmod.experience.source.builtin.util.AntiFarmingPerChunk;
+import net.puffish.skillsmod.util.LegacyUtils;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.Optional;
+
+public class ExtendedKillEntityExperienceSource extends KillEntityExperienceSource {
+        protected static final Identifier ID = SkillsMod.createIdentifier("kill_entity");
+        protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+
+        static {
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_player"),
+                                BuiltinPrototypes.PLAYER,
+                                OperationFactory.create(Data::player)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_weapon_item_stack"),
+                                BuiltinPrototypes.ITEM_STACK,
+                                OperationFactory.create(Data::weapon)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_killed_living_entity"),
+                                BuiltinPrototypes.LIVING_ENTITY,
+                                OperationFactory.create(Data::entity)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_damage_source"),
+                                BuiltinPrototypes.DAMAGE_SOURCE,
+                                OperationFactory.create(Data::damageSource)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_dropped_experience"),
+                                BuiltinPrototypes.NUMBER,
+                                OperationFactory.create(Data::entityDroppedXp)
+                );
+        }
+
+        private ExtendedKillEntityExperienceSource(Calculation<Data> calculation, Optional<AntiFarmingPerChunk> optAntiFarming) {
+                super(calculation, optAntiFarming);
+        }
+
+        public static void register() {
+                SkillsAPI.registerExperienceSource(
+                                ID,
+                                ExtendedKillEntityExperienceSource::parse
+                );
+        }
+
+        private static Result<ExtendedKillEntityExperienceSource, Problem> parse(ExperienceSourceConfigContext context) {
+                return context.getData()
+                                .andThen(JsonElement::getAsObject)
+                                .andThen(LegacyUtils.wrapNoUnused(rootObject -> parse(rootObject, context), context));
+        }
+        private static Result<ExtendedKillEntityExperienceSource, Problem> parse(JsonObject rootObject, ConfigContext context) {
+                var problems = new ArrayList<Problem>();
+
+                var variables = rootObject.get("variables")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(variablesElement -> Variables.parse(variablesElement, PROTOTYPE, context)
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElseGet(() -> Variables.create(Map.of()));
+
+                var optCalculation = rootObject.get("experience")
+                                .andThen(experienceElement -> Calculation.parse(
+                                                experienceElement,
+                                                variables,
+                                                context
+                                ))
+                                .ifFailure(problems::add)
+                                .getSuccess();
+
+                var optAntiFarming = rootObject.get("anti_farming")
+                                .getSuccess()
+                                .flatMap(element -> AntiFarmingPerChunk.parse(element, context)
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                                .flatMap(Function.identity())
+                                );
+
+                if (problems.isEmpty()) {
+                        return Result.success(new ExtendedKillEntityExperienceSource(
+                                        optCalculation.orElseThrow(),
+                                        optAntiFarming
+                        ));
+                } else {
+                        return Result.failure(Problem.combine(problems));
+                }
+        }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedMineBlockExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedMineBlockExperienceSource.java
@@ -1,0 +1,86 @@
+package net.puffish.skillsmod.experience.source.builtin;
+
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.calculation.Calculation;
+import net.puffish.skillsmod.api.calculation.Variables;
+import net.puffish.skillsmod.api.calculation.operation.OperationFactory;
+import net.puffish.skillsmod.api.calculation.prototype.BuiltinPrototypes;
+import net.puffish.skillsmod.api.calculation.prototype.Prototype;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import java.util.ArrayList;
+import java.util.Map;
+
+public class ExtendedMineBlockExperienceSource extends MineBlockExperienceSource {
+        protected static final Identifier ID = SkillsMod.createIdentifier("mine_block");
+        protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+
+        static {
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_player"),
+                                BuiltinPrototypes.PLAYER,
+                                OperationFactory.create(Data::player)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_mined_block_state"),
+                                BuiltinPrototypes.BLOCK_STATE,
+                                OperationFactory.create(Data::blockState)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_tool_item_stack"),
+                                BuiltinPrototypes.ITEM_STACK,
+                                OperationFactory.create(Data::tool)
+                );
+        }
+
+        private ExtendedMineBlockExperienceSource(Calculation<Data> calculation) {
+                super(calculation);
+        }
+
+        public static void register() {
+                SkillsAPI.registerExperienceSource(
+                                ID,
+                                ExtendedMineBlockExperienceSource::parse
+                );
+        }
+
+        private static Result<ExtendedMineBlockExperienceSource, Problem> parse(ExperienceSourceConfigContext context) {
+                return context.getData()
+                                .andThen(JsonElement::getAsObject)
+                                .andThen(rootObject -> rootObject.noUnused(o -> parse(o, context)));
+        }
+
+        private static Result<ExtendedMineBlockExperienceSource, Problem> parse(JsonObject rootObject, ExperienceSourceConfigContext context) {
+                var problems = new ArrayList<Problem>();
+
+                var variables = rootObject.get("variables")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(variablesElement -> Variables.parse(variablesElement, PROTOTYPE, context)
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElseGet(() -> Variables.create(Map.of()));
+
+                var optCalculation = rootObject.get("experience")
+                                .andThen(experienceElement -> Calculation.parse(
+                                                experienceElement,
+                                                variables,
+                                                context
+                                ))
+                                .ifFailure(problems::add)
+                                .getSuccess();
+
+                if (problems.isEmpty()) {
+                        return Result.success(new ExtendedMineBlockExperienceSource(
+                                        optCalculation.orElseThrow()
+                        ));
+                } else {
+                        return Result.failure(Problem.combine(problems));
+                }
+        }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedTakeDamageExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/ExtendedTakeDamageExperienceSource.java
@@ -1,0 +1,92 @@
+package net.puffish.skillsmod.experience.source.builtin;
+
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.calculation.Calculation;
+import net.puffish.skillsmod.api.calculation.Variables;
+import net.puffish.skillsmod.api.calculation.operation.OperationFactory;
+import net.puffish.skillsmod.api.calculation.prototype.BuiltinPrototypes;
+import net.puffish.skillsmod.api.calculation.prototype.Prototype;
+import net.puffish.skillsmod.api.experience.source.ExperienceSourceConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import java.util.ArrayList;
+import java.util.Map;
+
+
+public class ExtendedTakeDamageExperienceSource extends TakeDamageExperienceSource {
+        protected static final Identifier ID = SkillsMod.createIdentifier("take_damage");
+        protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+
+        static {
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_player"),
+                                BuiltinPrototypes.PLAYER,
+                                OperationFactory.create(Data::player)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_weapon_item_stack"),
+                                BuiltinPrototypes.ITEM_STACK,
+                                OperationFactory.create(Data::weapon)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_damage_source"),
+                                BuiltinPrototypes.DAMAGE_SOURCE,
+                                OperationFactory.create(Data::damageSource)
+                );
+                PROTOTYPE.registerOperation(
+                                SkillsMod.createIdentifier("get_taken_damage"),
+                                BuiltinPrototypes.NUMBER,
+                                OperationFactory.create(data -> (double) data.damage())
+                );
+        }
+
+        private ExtendedTakeDamageExperienceSource(Calculation<Data> calculation) {
+                super(calculation);
+        }
+
+        public static void register() {
+                SkillsAPI.registerExperienceSource(
+                                ID,
+                                ExtendedTakeDamageExperienceSource::parse
+                );
+        }
+
+        private static Result<ExtendedTakeDamageExperienceSource, Problem> parse(ExperienceSourceConfigContext context) {
+                return context.getData()
+                                .andThen(JsonElement::getAsObject)
+                                .andThen(rootObject -> rootObject.noUnused(o -> parse(o, context)));
+        }
+
+        private static Result<ExtendedTakeDamageExperienceSource, Problem> parse(JsonObject rootObject, ExperienceSourceConfigContext context) {
+                var problems = new ArrayList<Problem>();
+
+                var variables = rootObject.get("variables")
+                                .getSuccess() // ignore failure because this property is optional
+                                .flatMap(variablesElement -> Variables.parse(variablesElement, PROTOTYPE, context)
+                                                .ifFailure(problems::add)
+                                                .getSuccess()
+                                )
+                                .orElseGet(() -> Variables.create(Map.of()));
+
+                var optCalculation = rootObject.get("experience")
+                                .andThen(experienceElement -> Calculation.parse(
+                                                experienceElement,
+                                                variables,
+                                                context
+                                ))
+                                .ifFailure(problems::add)
+                                .getSuccess();
+
+                if (problems.isEmpty()) {
+                        return Result.success(new ExtendedTakeDamageExperienceSource(
+                                        optCalculation.orElseThrow()
+                        ));
+                } else {
+                        return Result.failure(Problem.combine(problems));
+                }
+        }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/IncreaseStatExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/IncreaseStatExperienceSource.java
@@ -23,8 +23,8 @@ import net.puffish.skillsmod.calculation.operation.builtin.EffectOperation;
 import net.puffish.skillsmod.calculation.operation.builtin.StatCondition;
 
 public class IncreaseStatExperienceSource implements ExperienceSource {
-	private static final Identifier ID = SkillsMod.createIdentifier("increase_stat");
-	private static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+	protected static final Identifier ID = SkillsMod.createIdentifier("increase_stat");
+	protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
 
 	static {
 		PROTOTYPE.registerOperation(
@@ -44,9 +44,9 @@ public class IncreaseStatExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private final Calculation<Data> calculation;
+	protected final Calculation<Data> calculation;
 
-	private IncreaseStatExperienceSource(Calculation<Data> calculation) {
+	protected IncreaseStatExperienceSource(Calculation<Data> calculation) {
 		this.calculation = calculation;
 	}
 
@@ -64,7 +64,7 @@ public class IncreaseStatExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private record Data(ServerPlayerEntity player, Stat<?> stat, int amount) { }
+	protected record Data(ServerPlayerEntity player, Stat<?> stat, int amount) { }
 
 	public int getValue(ServerPlayerEntity player, Stat<?> stat, int amount) {
 		return (int) Math.round(calculation.evaluate(

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/KillEntityExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/KillEntityExperienceSource.java
@@ -39,8 +39,8 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public class KillEntityExperienceSource implements ExperienceSource {
-	private static final Identifier ID = SkillsMod.createIdentifier("kill_entity");
-	private static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+	protected static final Identifier ID = SkillsMod.createIdentifier("kill_entity");
+	protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
 
 	static {
 		PROTOTYPE.registerOperation(
@@ -70,10 +70,10 @@ public class KillEntityExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private final Calculation<Data> calculation;
-	private final Optional<AntiFarmingPerChunk> optAntiFarming;
+	protected final Calculation<Data> calculation;
+	protected final Optional<AntiFarmingPerChunk> optAntiFarming;
 
-	private KillEntityExperienceSource(Calculation<Data> calculation, Optional<AntiFarmingPerChunk> optAntiFarming) {
+	protected KillEntityExperienceSource(Calculation<Data> calculation, Optional<AntiFarmingPerChunk> optAntiFarming) {
 		this.calculation = calculation;
 		this.optAntiFarming = optAntiFarming;
 	}
@@ -115,7 +115,7 @@ public class KillEntityExperienceSource implements ExperienceSource {
 		}
 	}
 
-	private record Data(ServerPlayerEntity player, LivingEntity entity, ItemStack weapon, DamageSource damageSource, double entityDroppedXp) { }
+	protected record Data(ServerPlayerEntity player, LivingEntity entity, ItemStack weapon, DamageSource damageSource, double entityDroppedXp) { }
 
 	public int getValue(ServerPlayerEntity player, LivingEntity entity, ItemStack weapon, DamageSource damageSource, double entityDroppedXp) {
 		return (int) Math.round(calculation.evaluate(

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/MineBlockExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/MineBlockExperienceSource.java
@@ -27,8 +27,8 @@ import net.puffish.skillsmod.calculation.operation.builtin.legacy.LegacyBlockTag
 import net.puffish.skillsmod.calculation.operation.builtin.legacy.LegacyItemTagCondition;
 
 public class MineBlockExperienceSource implements ExperienceSource {
-	private static final Identifier ID = SkillsMod.createIdentifier("mine_block");
-	private static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+	protected static final Identifier ID = SkillsMod.createIdentifier("mine_block");
+	protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
 
 	static {
 		PROTOTYPE.registerOperation(
@@ -48,9 +48,9 @@ public class MineBlockExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private final Calculation<Data> calculation;
+	protected final Calculation<Data> calculation;
 
-	private MineBlockExperienceSource(Calculation<Data> calculation) {
+	protected MineBlockExperienceSource(Calculation<Data> calculation) {
 		this.calculation = calculation;
 	}
 
@@ -68,7 +68,7 @@ public class MineBlockExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private record Data(ServerPlayerEntity player, BlockState blockState, ItemStack tool) { }
+	protected record Data(ServerPlayerEntity player, BlockState blockState, ItemStack tool) { }
 
 	public int getValue(ServerPlayerEntity player, BlockState blockState, ItemStack tool) {
 		return (int) Math.round(calculation.evaluate(

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/TakeDamageExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/TakeDamageExperienceSource.java
@@ -30,8 +30,8 @@ import net.puffish.skillsmod.calculation.operation.builtin.legacy.LegacyEntityTy
 import java.util.Optional;
 
 public class TakeDamageExperienceSource implements ExperienceSource {
-	private static final Identifier ID = SkillsMod.createIdentifier("take_damage");
-	private static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
+	protected static final Identifier ID = SkillsMod.createIdentifier("take_damage");
+	protected static final Prototype<Data> PROTOTYPE = Prototype.create(ID);
 
 	static {
 		PROTOTYPE.registerOperation(
@@ -56,9 +56,9 @@ public class TakeDamageExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private final Calculation<Data> calculation;
+	protected final Calculation<Data> calculation;
 
-	private TakeDamageExperienceSource(Calculation<Data> calculation) {
+	protected TakeDamageExperienceSource(Calculation<Data> calculation) {
 		this.calculation = calculation;
 	}
 
@@ -76,7 +76,7 @@ public class TakeDamageExperienceSource implements ExperienceSource {
 		);
 	}
 
-	private record Data(ServerPlayerEntity player, ItemStack weapon, float damage, DamageSource damageSource) { }
+	protected record Data(ServerPlayerEntity player, ItemStack weapon, float damage, DamageSource damageSource) { }
 
 	public int getValue(ServerPlayerEntity player, ItemStack weapon, float damage, DamageSource damageSource) {
 		return (int) Math.round(calculation.evaluate(


### PR DESCRIPTION
## Summary
- expand item crafting, eating, stat increase, entity kill, block mining and damage sources with Extended variants that parse modern variable-based expressions
- expose underlying fields in original sources for subclassing and register Extended implementations

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689858d012608327af30fb4bbc423664