### PR TITLE
Add extended config wrappers for skill levels

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/config/ExtendedCategoryConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/ExtendedCategoryConfig.java
@@ -1,0 +1,80 @@
+package net.puffish.skillsmod.config;
+
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.api.config.ConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.config.experience.ExperienceConfig;
+import net.puffish.skillsmod.config.skill.ExtendedSkillDefinitionsConfig;
+import net.puffish.skillsmod.config.skill.SkillConnectionsConfig;
+import net.puffish.skillsmod.config.skill.SkillsConfig;
+import net.puffish.skillsmod.util.DisposeContext;
+import net.puffish.skillsmod.impl.json.JsonElementImpl;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+/**
+ * Wrapper over {@link CategoryConfig} that exposes the extended
+ * {@link ExtendedSkillDefinitionsConfig}. Base parsing and validation
+ * are delegated to {@link CategoryConfig} to keep behaviour consistent
+ * with the original implementation.
+ */
+public record ExtendedCategoryConfig(
+        Identifier id,
+        GeneralConfig general,
+        ExtendedSkillDefinitionsConfig definitions,
+        SkillsConfig skills,
+        SkillConnectionsConfig connections,
+        Optional<ExperienceConfig> experience
+) {
+
+    public static Result<ExtendedCategoryConfig, Problem> parse(
+            Identifier id,
+            JsonElement generalElement,
+            JsonElement definitionsElement,
+            JsonElement skillsElement,
+            JsonElement connectionsElement,
+            Optional<JsonElement> optExperienceElement,
+            ConfigContext context
+    ) {
+        var problems = new ArrayList<Problem>();
+
+        // Parse extended definitions on a copy to avoid interfering with base parsing
+        var definitionsCopy = new JsonElementImpl(definitionsElement.getJson().deepCopy(), definitionsElement.getPath());
+        var optDefinitions = ExtendedSkillDefinitionsConfig.parse(definitionsCopy, context)
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        var optBase = CategoryConfig.parse(
+                id,
+                generalElement,
+                definitionsElement,
+                skillsElement,
+                connectionsElement,
+                optExperienceElement,
+                context
+        ).ifFailure(problems::add).getSuccess();
+
+        if (problems.isEmpty()) {
+            var base = optBase.orElseThrow();
+            return Result.success(new ExtendedCategoryConfig(
+                    base.id(),
+                    base.general(),
+                    optDefinitions.orElseThrow(),
+                    base.skills(),
+                    base.connections(),
+                    base.experience()
+            ));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    public void dispose(DisposeContext context) {
+        definitions.dispose(context);
+        experience.ifPresent(exp -> exp.dispose(context));
+    }
+}
+

--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/ExtendedSkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/ExtendedSkillDefinitionConfig.java
@@ -1,0 +1,130 @@
+package net.puffish.skillsmod.config.skill;
+
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.api.config.ConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.config.FrameConfig;
+import net.puffish.skillsmod.config.IconConfig;
+import net.puffish.skillsmod.config.skill.SkillRewardConfig;
+import net.puffish.skillsmod.util.DisposeContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Extension of {@link SkillDefinitionConfig} that exposes the additional
+ * {@code points_per_level} property used by level rewards. The remaining
+ * fields are delegated to the wrapped {@link SkillDefinitionConfig}
+ * instance so the original parsing and validation logic is preserved.
+ */
+public class ExtendedSkillDefinitionConfig {
+    private final SkillDefinitionConfig base;
+    private final int pointsPerLevel;
+
+    private ExtendedSkillDefinitionConfig(SkillDefinitionConfig base, int pointsPerLevel) {
+        this.base = base;
+        this.pointsPerLevel = pointsPerLevel;
+    }
+
+    public static Result<ExtendedSkillDefinitionConfig, Problem> parse(String id, JsonElement rootElement, ConfigContext context) {
+        return rootElement.getAsObject().andThen(obj -> parse(id, obj, context));
+    }
+
+    public static Result<ExtendedSkillDefinitionConfig, Problem> parse(String id, JsonObject rootObject, ConfigContext context) {
+        var problems = new ArrayList<Problem>();
+
+        // Read the extra points_per_level field while leaving validation to the base parser
+        int pointsPerLevel = rootObject.get("points_per_level")
+                .getSuccess()
+                .flatMap(element -> element.getAsInt().getSuccess())
+                .orElse(0);
+
+        var optBase = SkillDefinitionConfig.parse(id, rootObject, context)
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        if (problems.isEmpty()) {
+            return Result.success(new ExtendedSkillDefinitionConfig(optBase.orElseThrow(), pointsPerLevel));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    // ---- Delegated accessors ----
+
+    public String id() {
+        return base.id();
+    }
+
+    public Identifier type() {
+        return base.type();
+    }
+
+    public int maxLevels() {
+        return base.maxLevels();
+    }
+
+    public List<Text> descriptions() {
+        return base.descriptions();
+    }
+
+    public List<Text> extraDescriptions() {
+        return base.extraDescriptions();
+    }
+
+    public Text title() {
+        return base.title();
+    }
+
+    public IconConfig icon() {
+        return base.icon();
+    }
+
+    public FrameConfig frame() {
+        return base.frame();
+    }
+
+    public float size() {
+        return base.size();
+    }
+
+    public boolean mergeDescription() {
+        return base.mergeDescription();
+    }
+
+    public List<SkillRewardConfig> rewards() {
+        return base.rewards();
+    }
+
+    public int cost() {
+        return base.cost();
+    }
+
+    public int requiredSkills() {
+        return base.requiredSkills();
+    }
+
+    public int requiredPoints() {
+        return base.requiredPoints();
+    }
+
+    public int requiredSpentPoints() {
+        return base.requiredSpentPoints();
+    }
+
+    public int requiredExclusions() {
+        return base.requiredExclusions();
+    }
+
+    public int pointsPerLevel() {
+        return pointsPerLevel;
+    }
+
+    public void dispose(DisposeContext context) {
+        base.dispose(context);
+    }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/ExtendedSkillDefinitionsConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/ExtendedSkillDefinitionsConfig.java
@@ -1,0 +1,70 @@
+package net.puffish.skillsmod.config.skill;
+
+import net.puffish.skillsmod.api.config.ConfigContext;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.impl.json.JsonObjectImpl;
+import net.puffish.skillsmod.util.DisposeContext;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Collection of {@link ExtendedSkillDefinitionConfig} objects. The base
+ * {@link SkillDefinitionsConfig} parsing is delegated to ensure the
+ * original validation rules are applied.
+ */
+public class ExtendedSkillDefinitionsConfig {
+    private final SkillDefinitionsConfig base;
+    private final Map<String, ExtendedSkillDefinitionConfig> definitions;
+
+    private ExtendedSkillDefinitionsConfig(SkillDefinitionsConfig base, Map<String, ExtendedSkillDefinitionConfig> definitions) {
+        this.base = base;
+        this.definitions = definitions;
+    }
+
+    public static Result<ExtendedSkillDefinitionsConfig, Problem> parse(JsonElement rootElement, ConfigContext context) {
+        return rootElement.getAsObject().andThen(obj -> parse(obj, context));
+    }
+
+    public static Result<ExtendedSkillDefinitionsConfig, Problem> parse(JsonObject rootObject, ConfigContext context) {
+        var problems = new ArrayList<Problem>();
+
+        // Parse extended definitions from a copy so we can reuse the original object for the base parser
+        var copy = new JsonObjectImpl(rootObject.getJson().deepCopy(), rootObject.getPath());
+        var optExt = copy.getAsMap((id, element) -> ExtendedSkillDefinitionConfig.parse(id, element, context))
+                .mapFailure(map -> Problem.combine(map.values()))
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        var optBase = SkillDefinitionsConfig.parse(rootObject, context)
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        if (problems.isEmpty()) {
+            return Result.success(new ExtendedSkillDefinitionsConfig(optBase.orElseThrow(), optExt.orElseThrow()));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    public Optional<ExtendedSkillDefinitionConfig> getById(String id) {
+        return Optional.ofNullable(definitions.get(id));
+    }
+
+    public Collection<ExtendedSkillDefinitionConfig> getAll() {
+        return definitions.values();
+    }
+
+    public SkillDefinitionsConfig base() {
+        return base;
+    }
+
+    public void dispose(DisposeContext context) {
+        base.dispose(context);
+    }
+}


### PR DESCRIPTION
## Summary
- add ExtendedSkillDefinitionConfig exposing `points_per_level`
- implement ExtendedSkillDefinitionsConfig wrapper around original definitions
- add ExtendedCategoryConfig delegating base parsing while using extended definitions

## Testing
- `./gradlew test`
- `./gradlew check`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689858d2cfac8327a4cf988769607aab