### PR TITLE
Add extended reward registration

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -37,7 +37,7 @@ import net.puffish.skillsmod.experience.source.BuiltinExperienceSources;
 import net.puffish.skillsmod.impl.config.ConfigContextImpl;
 import net.puffish.skillsmod.impl.rewards.RewardUpdateContextImpl;
 import net.puffish.skillsmod.network.Packets;
-import net.puffish.skillsmod.reward.BuiltinRewards;
+import net.puffish.skillsmod.reward.ExtendedBuiltinRewards;
 import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
 import net.puffish.skillsmod.reward.builtin.PointsReward;
 import net.puffish.skillsmod.server.data.CategoryData;
@@ -154,7 +154,7 @@ public class SkillsMod {
 		SkillsGameRules.register(registrar);
 		SkillsArgumentTypes.register(registrar);
 
-		BuiltinRewards.register();
+               ExtendedBuiltinRewards.register();
 		BuiltinOperations.register();
 		BuiltinExperienceSources.register();
 

--- a/Common/src/main/java/net/puffish/skillsmod/reward/ExtendedBuiltinRewards.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/ExtendedBuiltinRewards.java
@@ -1,0 +1,18 @@
+package net.puffish.skillsmod.reward;
+
+import net.puffish.skillsmod.reward.builtin.ExtendedCommandReward;
+
+/**
+ * Registers the default rewards along with additional extended reward types.
+ * This allows addons to provide new built-in rewards without modifying the
+ * original registration code.
+ */
+public class ExtendedBuiltinRewards extends BuiltinRewards {
+    /**
+     * Registers both the standard and extended reward implementations.
+     */
+    public static void register() {
+        BuiltinRewards.register();
+        ExtendedCommandReward.register();
+    }
+}

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/CommandReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/CommandReward.java
@@ -25,15 +25,16 @@ public class CommandReward implements Reward {
 
 	private final Map<UUID, Integer> counts = new HashMap<>();
 
-	private final String command;
-	private final String unlockCommand;
-	private final String lockCommand;
+       private final String command;
+       private final String unlockCommand;
+       private final String lockCommand;
 
-	private CommandReward(String command, String unlockCommand, String lockCommand) {
-		this.command = command;
-		this.unlockCommand = unlockCommand;
-		this.lockCommand = lockCommand;
-	}
+       // Protected to allow extensions such as server command rewards
+       protected CommandReward(String command, String unlockCommand, String lockCommand) {
+               this.command = command;
+               this.unlockCommand = unlockCommand;
+               this.lockCommand = lockCommand;
+       }
 
 	public static void register() {
 		SkillsAPI.registerReward(
@@ -86,20 +87,21 @@ public class CommandReward implements Reward {
 		}
 	}
 
-	private void executeCommand(ServerPlayerEntity player, String command) {
-		if (command.isBlank()) {
-			return;
-		}
+       // Protected so subclasses can override command execution behaviour
+       protected void executeCommand(ServerPlayerEntity player, String command) {
+               if (command.isBlank()) {
+                       return;
+               }
 
-		var server = Objects.requireNonNull(player.getServer());
+               var server = Objects.requireNonNull(player.getServer());
 
-		server.getCommandManager().executeWithPrefix(
-				player.getCommandSource()
-						.withSilent()
-						.withLevel(server.getFunctionPermissionLevel()),
-				command
-		);
-	}
+               server.getCommandManager().executeWithPrefix(
+                               player.getCommandSource()
+                                               .withSilent()
+                                               .withLevel(server.getFunctionPermissionLevel()),
+                               command
+               );
+       }
 
 	@Override
 	public void update(RewardUpdateContext context) {

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/ExtendedCommandReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/ExtendedCommandReward.java
@@ -1,0 +1,78 @@
+package net.puffish.skillsmod.reward.builtin;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.reward.RewardConfigContext;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.util.LegacyUtils;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+/**
+ * A variant of {@link CommandReward} that executes commands from the server
+ * instead of the player. Useful for rewards that require elevated privileges
+ * or should not depend on the player's command permissions.
+ */
+public class ExtendedCommandReward extends CommandReward {
+    public static final Identifier ID = SkillsMod.createIdentifier("server_command");
+
+    private ExtendedCommandReward(String command, String unlockCommand, String lockCommand) {
+        super(command, unlockCommand, lockCommand);
+    }
+
+    public static void register() {
+        SkillsAPI.registerReward(ID, ExtendedCommandReward::parse);
+    }
+
+    private static Result<ExtendedCommandReward, Problem> parse(RewardConfigContext context) {
+        return context.getData()
+                .andThen(JsonElement::getAsObject)
+                .andThen(LegacyUtils.wrapNoUnused(ExtendedCommandReward::parse, context));
+    }
+
+    private static Result<ExtendedCommandReward, Problem> parse(JsonObject rootObject) {
+        var problems = new ArrayList<Problem>();
+
+        var command = rootObject.get("command")
+                .getSuccess()
+                .flatMap(element -> element.getAsString().ifFailure(problems::add).getSuccess())
+                .orElse("");
+
+        var unlockCommand = rootObject.get("unlock_command")
+                .getSuccess()
+                .flatMap(element -> element.getAsString().ifFailure(problems::add).getSuccess())
+                .orElse("");
+
+        var lockCommand = rootObject.get("lock_command")
+                .getSuccess()
+                .flatMap(element -> element.getAsString().ifFailure(problems::add).getSuccess())
+                .orElse("");
+
+        if (problems.isEmpty()) {
+            return Result.success(new ExtendedCommandReward(command, unlockCommand, lockCommand));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    @Override
+    protected void executeCommand(ServerPlayerEntity player, String command) {
+        if (command.isBlank()) {
+            return;
+        }
+
+        var server = Objects.requireNonNull(player.getServer());
+        server.getCommandManager().executeWithPrefix(
+                server.getCommandSource()
+                        .withSilent()
+                        .withLevel(server.getFunctionPermissionLevel()),
+                command
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Allow CommandReward to be subclassed and override execution
- Add ExtendedCommandReward for executing reward commands as the server
- Register extended reward types via ExtendedBuiltinRewards

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689858d2439883279cc2831f8872f684