### PR TITLE
Inject refund subcommand extension

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -22,7 +22,7 @@ import net.puffish.skillsmod.commands.CategoryCommand;
 import net.puffish.skillsmod.commands.ExperienceCommand;
 import net.puffish.skillsmod.commands.OpenCommand;
 import net.puffish.skillsmod.commands.PointsCommand;
-import net.puffish.skillsmod.commands.SkillsCommand;
+import net.puffish.skillsmod.commands.ExtendedSkillsCommand;
 import net.puffish.skillsmod.config.CategoryConfig;
 import net.puffish.skillsmod.config.Config;
 import net.puffish.skillsmod.config.ModConfig;
@@ -918,7 +918,7 @@ public class SkillsMod {
 		public void onCommandsRegister(CommandDispatcher<ServerCommandSource> dispatcher) {
 			dispatcher.register(CommandManager.literal(SkillsAPI.MOD_ID)
 					.then(CategoryCommand.create())
-					.then(SkillsCommand.create())
+.then(ExtendedSkillsCommand.create())
 					.then(PointsCommand.create())
 					.then(ExperienceCommand.create())
 					.then(OpenCommand.create())

--- a/Common/src/main/java/net/puffish/skillsmod/commands/ExtendedSkillsCommand.java
+++ b/Common/src/main/java/net/puffish/skillsmod/commands/ExtendedSkillsCommand.java
@@ -1,0 +1,13 @@
+package net.puffish.skillsmod.commands;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.server.command.ServerCommandSource;
+
+public class ExtendedSkillsCommand extends SkillsCommand {
+	public static LiteralArgumentBuilder<ServerCommandSource> create() {
+		var root = SkillsCommand.create();
+		RefundCommandExtension.inject(root);
+		return root;
+	}
+}
+

--- a/Common/src/main/java/net/puffish/skillsmod/commands/RefundCommandExtension.java
+++ b/Common/src/main/java/net/puffish/skillsmod/commands/RefundCommandExtension.java
@@ -1,0 +1,120 @@
+package net.puffish.skillsmod.commands;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import net.minecraft.command.argument.EntityArgumentType;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.commands.arguments.CategoryArgumentType;
+import net.puffish.skillsmod.commands.arguments.SkillArgumentType;
+import net.puffish.skillsmod.util.CommandUtils;
+
+public class RefundCommandExtension {
+	public static void inject(LiteralArgumentBuilder<ServerCommandSource> root) {
+		root.then(CommandManager.literal("refund")
+				.then(CommandManager.argument("players", EntityArgumentType.players())
+						.then(CommandManager.argument("category", CategoryArgumentType.category())
+								.then(CommandManager.argument("skill", SkillArgumentType.skillFromCategory("category"))
+										.executes(RefundCommandExtension::refund)
+										.then(CommandManager.argument("count", IntegerArgumentType.integer(1))
+												.executes(RefundCommandExtension::refundCount)
+										)
+										.then(CommandManager.literal("all")
+												.executes(RefundCommandExtension::refundAll)
+										)
+								)
+						)
+				));
+	}
+
+	private static int refund(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		return refund(context, 1);
+	}
+
+	private static int refund(CommandContext<ServerCommandSource> context, int count) throws CommandSyntaxException {
+		var players = EntityArgumentType.getPlayers(context, "players");
+		var category = CategoryArgumentType.getCategory(context, "category");
+		var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
+
+		var refunded = false;
+		for (var player : players) {
+			for (var i = 0; i < count; i++) {
+				if (!SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId())) {
+					break;
+				}
+				refunded = true;
+			}
+		}
+
+		if (refunded) {
+			if (count == 1) {
+				CommandUtils.sendSuccess(
+						context,
+						players,
+						"skills.refund",
+						skill.getId(),
+						category.getId()
+				);
+			} else {
+				CommandUtils.sendSuccess(
+						context,
+						players,
+						"skills.refund_many",
+						count,
+						skill.getId(),
+						category.getId()
+				);
+			}
+			return players.size();
+		} else {
+			context.getSource().sendError(SkillsMod.createTranslatable(
+					"command",
+					"skills.refund.no_levels",
+					skill.getId(),
+					category.getId()
+			));
+			return 0;
+		}
+	}
+
+	private static int refundCount(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		var count = IntegerArgumentType.getInteger(context, "count");
+		return refund(context, count);
+	}
+
+	private static int refundAll(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		var players = EntityArgumentType.getPlayers(context, "players");
+		var category = CategoryArgumentType.getCategory(context, "category");
+		var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
+
+		var refunded = false;
+		for (var player : players) {
+			while (SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId())) {
+				refunded = true;
+			}
+		}
+
+		if (refunded) {
+			CommandUtils.sendSuccess(
+					context,
+					players,
+					"skills.refund_all",
+					skill.getId(),
+					category.getId()
+			);
+			return players.size();
+		} else {
+			context.getSource().sendError(SkillsMod.createTranslatable(
+					"command",
+					"skills.refund.no_levels",
+					skill.getId(),
+					category.getId()
+			));
+			return 0;
+		}
+	}
+}
+

--- a/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
+++ b/Common/src/main/java/net/puffish/skillsmod/commands/SkillsCommand.java
@@ -3,14 +3,12 @@ package net.puffish.skillsmod.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.puffish.skillsmod.commands.arguments.CategoryArgumentType;
 import net.puffish.skillsmod.commands.arguments.SkillArgumentType;
 import net.puffish.skillsmod.util.CommandUtils;
-import net.puffish.skillsmod.SkillsMod;
 
 public class SkillsCommand {
 	public static LiteralArgumentBuilder<ServerCommandSource> create() {
@@ -34,29 +32,14 @@ public class SkillsCommand {
 								)
 						)
 				)
-                                .then(CommandManager.literal("reset")
-                                                .then(CommandManager.argument("players", EntityArgumentType.players())
-                                                                .then(CommandManager.argument("category", CategoryArgumentType.category())
-                                                                                .executes(SkillsCommand::reset)
-                                                                )
-                                                )
-                                )
-                                .then(CommandManager.literal("refund")
-                                                .then(CommandManager.argument("players", EntityArgumentType.players())
-                                                                .then(CommandManager.argument("category", CategoryArgumentType.category())
-                                                                                .then(CommandManager.argument("skill", SkillArgumentType.skillFromCategory("category"))
-                                                                                                .executes(SkillsCommand::refund)
-                                                                                                .then(CommandManager.argument("count", IntegerArgumentType.integer(1))
-                                                                                                                .executes(SkillsCommand::refundCount)
-                                                                                                )
-                                                                                                .then(CommandManager.literal("all")
-                                                                                                                .executes(SkillsCommand::refundAll)
-                                                                                                )
-                                                                                )
-                                                                )
-                                                )
-                                );
-        }
+				.then(CommandManager.literal("reset")
+						.then(CommandManager.argument("players", EntityArgumentType.players())
+								.then(CommandManager.argument("category", CategoryArgumentType.category())
+										.executes(SkillsCommand::reset)
+								)
+						)
+				);
+	}
 
 	private static int unlock(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
 		var players = EntityArgumentType.getPlayers(context, "players");
@@ -94,9 +77,9 @@ public class SkillsCommand {
 		return players.size();
 	}
 
-        private static int reset(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-                var players = EntityArgumentType.getPlayers(context, "players");
-                var category = CategoryArgumentType.getCategory(context, "category");
+	private static int reset(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		var players = EntityArgumentType.getPlayers(context, "players");
+		var category = CategoryArgumentType.getCategory(context, "category");
 
 		for (var player : players) {
 			category.resetSkills(player);
@@ -107,93 +90,6 @@ public class SkillsCommand {
 				"skills.reset",
 				category.getId()
 		);
-                return players.size();
-        }
-
-       private static int refund(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-               return refund(context, 1);
-       }
-
-       private static int refund(CommandContext<ServerCommandSource> context, int count) throws CommandSyntaxException {
-               var players = EntityArgumentType.getPlayers(context, "players");
-               var category = CategoryArgumentType.getCategory(context, "category");
-               var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
-
-               var refunded = false;
-               for (var player : players) {
-                       for (var i = 0; i < count; i++) {
-                               if (!SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId())) {
-                                       break;
-                               }
-                               refunded = true;
-                       }
-               }
-
-               if (refunded) {
-                       if (count == 1) {
-                               CommandUtils.sendSuccess(
-                                               context,
-                                               players,
-                                               "skills.refund",
-                                               skill.getId(),
-                                               category.getId()
-                               );
-                       } else {
-                               CommandUtils.sendSuccess(
-                                               context,
-                                               players,
-                                               "skills.refund_many",
-                                               count,
-                                               skill.getId(),
-                                               category.getId()
-                               );
-                       }
-                       return players.size();
-               } else {
-                       context.getSource().sendError(SkillsMod.createTranslatable(
-                                       "command",
-                                       "skills.refund.no_levels",
-                                       skill.getId(),
-                                       category.getId()
-                       ));
-                       return 0;
-               }
-       }
-
-       private static int refundCount(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-               var count = IntegerArgumentType.getInteger(context, "count");
-               return refund(context, count);
-       }
-
-       private static int refundAll(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-               var players = EntityArgumentType.getPlayers(context, "players");
-               var category = CategoryArgumentType.getCategory(context, "category");
-               var skill = SkillArgumentType.getSkillFromCategory(context, "skill", category);
-
-               var refunded = false;
-               for (var player : players) {
-                       while (SkillsMod.getInstance().refundSkill(player, category.getId(), skill.getId())) {
-                               refunded = true;
-                       }
-               }
-
-               if (refunded) {
-                       CommandUtils.sendSuccess(
-                                       context,
-                                       players,
-                                       "skills.refund_all",
-                                       skill.getId(),
-                                       category.getId()
-                       );
-                       return players.size();
-               } else {
-                       context.getSource().sendError(SkillsMod.createTranslatable(
-                                       "command",
-                                       "skills.refund.no_levels",
-                                       skill.getId(),
-                                       category.getId()
-                       ));
-                       return 0;
-               }
-       }
+		return players.size();
+	}
 }


### PR DESCRIPTION
## Summary
- extend the upstream skills command with `ExtendedSkillsCommand`
- wire in `RefundCommandExtension` to provide refund subcommands
- register the extended command for server command dispatching

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_689858d3ebe88327bc06324663fcd8d8