### PR TITLE
Add extended client components and packet wrappers

### DIFF
--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/ExtendedSkillsClientMod.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/ExtendedSkillsClientMod.java
@@ -1,0 +1,199 @@
+package net.bluelotuscoding.puffishskillleveling.client;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.bluelotuscoding.puffishskillleveling.client.data.ExtendedClientSkillScreenData;
+import net.puffish.skillsmod.client.event.ClientEventListener;
+import net.puffish.skillsmod.client.event.ClientEventReceiver;
+import net.puffish.skillsmod.client.gui.SimpleToast;
+import net.bluelotuscoding.puffishskillleveling.client.gui.ExtendedSkillsScreen;
+import net.puffish.skillsmod.client.keybinding.KeyBindingReceiver;
+import net.puffish.skillsmod.client.network.ClientPacketSender;
+import net.puffish.skillsmod.client.network.packets.in.ExperienceUpdateInPacket;
+import net.puffish.skillsmod.client.network.packets.in.HideCategoryInPacket;
+import net.puffish.skillsmod.client.network.packets.in.NewPointInPacket;
+import net.puffish.skillsmod.client.network.packets.in.OpenScreenInPacket;
+import net.puffish.skillsmod.client.network.packets.in.PointsUpdateInPacket;
+import net.bluelotuscoding.puffishskillleveling.client.network.packets.in.ExtendedShowCategoryInPacket;
+import net.puffish.skillsmod.client.network.packets.in.ShowToastInPacket;
+import net.bluelotuscoding.puffishskillleveling.client.network.packets.in.ExtendedSkillUpdateInPacket;
+import net.puffish.skillsmod.client.setup.ClientRegistrar;
+import net.puffish.skillsmod.network.Packets;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.Optional;
+
+public class ExtendedSkillsClientMod {
+	public static final KeyBinding OPEN_KEY_BINDING = new KeyBinding(
+			"key.puffish_skills.open",
+			InputUtil.Type.KEYSYM,
+			GLFW.GLFW_KEY_K,
+			"category.puffish_skills.skills"
+	);
+
+	private static ExtendedSkillsClientMod instance;
+
+	private final ExtendedClientSkillScreenData screenData = new ExtendedClientSkillScreenData();
+
+	private final ClientPacketSender packetSender;
+
+	private ExtendedSkillsClientMod(ClientPacketSender packetSender) {
+		this.packetSender = packetSender;
+	}
+
+	public static ExtendedSkillsClientMod getInstance() {
+		return instance;
+	}
+
+	public static void setup(
+			ClientRegistrar registrar,
+			ClientEventReceiver eventReceiver,
+			KeyBindingReceiver keyBindingReceiver,
+			ClientPacketSender packetSender
+	) {
+		instance = new ExtendedSkillsClientMod(packetSender);
+
+		keyBindingReceiver.registerKeyBinding(OPEN_KEY_BINDING, instance::onOpenKeyPress);
+
+		registrar.registerInPacket(
+				Packets.SHOW_CATEGORY,
+				ExtendedShowCategoryInPacket::read,
+				instance::onShowCategory
+		);
+
+		registrar.registerInPacket(
+				Packets.HIDE_CATEGORY,
+				HideCategoryInPacket::read,
+				instance::onHideCategory
+		);
+
+		registrar.registerInPacket(
+				Packets.SKILL_UPDATE,
+				ExtendedSkillUpdateInPacket::read,
+				instance::onSkillUpdatePacket
+		);
+
+		registrar.registerInPacket(
+				Packets.POINTS_UPDATE,
+				PointsUpdateInPacket::read,
+				instance::onPointsUpdatePacket
+		);
+
+		registrar.registerInPacket(
+				Packets.EXPERIENCE_UPDATE,
+				ExperienceUpdateInPacket::read,
+				instance::onExperienceUpdatePacket
+		);
+
+		registrar.registerInPacket(
+				Packets.SHOW_TOAST,
+				ShowToastInPacket::read,
+				instance::onShowToast
+		);
+
+		registrar.registerInPacket(
+				Packets.OPEN_SCREEN,
+				OpenScreenInPacket::read,
+				instance::onOpenScreenPacket
+		);
+
+		registrar.registerInPacket(
+				Packets.NEW_POINT,
+				NewPointInPacket::read,
+				instance::onNewPointPacket
+		);
+
+		registrar.registerOutPacket(Packets.SKILL_CLICK);
+
+		eventReceiver.registerListener(instance.new EventListener());
+	}
+
+	private void onOpenKeyPress() {
+		openScreen(Optional.empty());
+	}
+
+	private void onShowCategory(ExtendedShowCategoryInPacket packet) {
+		var category = packet.getCategory();
+		screenData.putCategory(category.getConfig().id(), category);
+	}
+
+	private void onHideCategory(HideCategoryInPacket packet) {
+		screenData.removeCategory(packet.getCategoryId());
+	}
+
+	private void onSkillUpdatePacket(ExtendedSkillUpdateInPacket packet) {
+                screenData.getCategory(packet.getCategoryId()).ifPresent(category -> {
+                        if (packet.isUnlocked()) {
+                                category.unlock(packet.getSkillId(), packet.getLevel());
+                        } else {
+                                category.lock(packet.getSkillId());
+                        }
+                });
+        }
+
+	private void onExperienceUpdatePacket(ExperienceUpdateInPacket packet) {
+		screenData.getCategory(packet.getCategoryId()).ifPresent(category -> {
+			category.setCurrentLevel(packet.getCurrentLevel());
+			category.setCurrentExperience(packet.getCurrentExperience());
+			category.setRequiredExperience(packet.getRequiredExperience());
+		});
+	}
+
+	private void onPointsUpdatePacket(PointsUpdateInPacket packet) {
+		screenData.getCategory(packet.getCategoryId()).ifPresent(category -> {
+			category.updatePoints(
+					packet.getSpentPoints(),
+					packet.getEarnedPoints()
+			);
+		});
+	}
+
+	private void onNewPointPacket(NewPointInPacket packet) {
+		screenData.getCategory(packet.getCategoryId()).ifPresent(category -> {
+			if (category.hasAnySkillLeft()) {
+				MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(
+						SkillsMod.createTranslatable(
+								"chat",
+								"new_point",
+								OPEN_KEY_BINDING.getBoundKeyLocalizedText()
+						)
+				);
+			}
+		});
+	}
+
+	private void onOpenScreenPacket(OpenScreenInPacket packet) {
+		openScreen(packet.getCategoryId());
+	}
+
+	private void onShowToast(ShowToastInPacket packet) {
+		var client = MinecraftClient.getInstance();
+		client.getToastManager().add(SimpleToast.create(
+				client,
+				Text.literal("Pufferfish's Skills"),
+				SkillsMod.createTranslatable("toast", switch (packet.getToastType()) {
+					case INVALID_CONFIG -> "invalid_config";
+					case MISSING_CONFIG -> "missing_config";
+				} + ".description")
+		));
+	}
+
+	public void openScreen(Optional<Identifier> categoryId) {
+		MinecraftClient.getInstance().setScreen(new ExtendedSkillsScreen(screenData, categoryId));
+	}
+
+	public ClientPacketSender getPacketSender() {
+		return packetSender;
+	}
+
+	private class EventListener implements ClientEventListener {
+		@Override
+		public void onPlayerJoin() {
+			screenData.clearCategories();
+		}
+	}
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/config/ExtendedClientBackgroundConfig.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/config/ExtendedClientBackgroundConfig.java
@@ -1,0 +1,96 @@
+package net.bluelotuscoding.puffishskillleveling.client.config;
+
+import com.mojang.blaze3d.platform.TextureUtil;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.texture.AbstractTexture;
+import net.minecraft.client.texture.Animator;
+import net.minecraft.client.texture.MissingSprite;
+import net.minecraft.client.texture.SpriteContents;
+import net.minecraft.client.texture.SpriteLoader;
+import net.minecraft.client.texture.TextureTickListener;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.common.BackgroundPosition;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.util.Optional;
+
+/**
+ * Extended variant of {@link net.puffish.skillsmod.client.config.ClientBackgroundConfig}
+ * that registers animated textures generated at runtime. This class is copied from
+ * the original implementation but lives in a different package so it can coexist
+ * with the base mod when used as an addon.
+ */
+public record ExtendedClientBackgroundConfig(
+                Identifier texture,
+                int width,
+                int height,
+                BackgroundPosition position
+) {
+        public static ExtendedClientBackgroundConfig create(
+                        Identifier textureId,
+                        int width,
+                        int height,
+                        BackgroundPosition position
+        ) {
+                var id = SkillsMod.createIdentifier(RandomStringUtils.random(16, "abcdefghijklmnopqrstuvwxyz0123456789"));
+                var texture = new ClientBackgroundTexture(textureId);
+                MinecraftClient.getInstance().submit(() ->
+                        MinecraftClient.getInstance()
+                                        .getTextureManager()
+                                        .registerTexture(id, texture)
+                );
+
+                return new ExtendedClientBackgroundConfig(
+                                id,
+                                width,
+                                height,
+                                position
+                );
+        }
+
+        private static class ClientBackgroundTexture extends AbstractTexture implements TextureTickListener {
+                private final Identifier id;
+                private SpriteContents sprite;
+                private Animator animator;
+
+                public ClientBackgroundTexture(Identifier id) {
+                        this.id = id;
+                }
+
+                @Override
+                public void load(ResourceManager manager) {
+                        sprite = manager
+                                        .getResource(id)
+                                        .flatMap(resource -> Optional.ofNullable(SpriteLoader.load(id, resource)))
+                                        .orElseGet(MissingSprite::createSpriteContents);
+                        animator = sprite.createAnimator();
+
+                        RenderSystem.recordRenderCall(() -> {
+                                bindTexture();
+                                TextureUtil.prepareImage(this.getGlId(), 0, sprite.getWidth(), sprite.getHeight());
+                                sprite.upload(0, 0);
+                        });
+                }
+
+                @Override
+                public void tick() {
+                        bindTexture();
+                        if (animator != null) {
+                                animator.tick(0, 0);
+                        }
+                }
+
+                @Override
+                public void close() {
+                        sprite.close();
+                        if (animator != null) {
+                                animator.close();
+                        }
+
+                        super.close();
+                }
+        }
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/config/ExtendedClientCategoryConfig.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/config/ExtendedClientCategoryConfig.java
@@ -1,0 +1,123 @@
+package net.bluelotuscoding.puffishskillleveling.client.config;
+
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.bluelotuscoding.puffishskillleveling.client.config.ExtendedClientBackgroundConfig;
+import net.puffish.skillsmod.client.config.ClientIconConfig;
+import net.puffish.skillsmod.client.config.colors.ClientColorsConfig;
+import net.puffish.skillsmod.client.config.skill.ClientSkillConfig;
+import net.puffish.skillsmod.client.config.skill.ClientSkillConnectionConfig;
+import net.bluelotuscoding.puffishskillleveling.client.config.skill.ExtendedClientSkillDefinitionConfig;
+import net.puffish.skillsmod.util.Bounds2i;
+import org.joml.Vector2i;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Variant of {@link net.puffish.skillsmod.client.config.ClientCategoryConfig}
+ * that stores {@link ExtendedClientSkillDefinitionConfig} entries. This is used by
+ * the client addon to retain additional data sent from the server while reusing
+ * the rest of the base configuration logic.
+ */
+public record ExtendedClientCategoryConfig(
+                Identifier id,
+                Text title,
+                ClientIconConfig icon,
+                ExtendedClientBackgroundConfig background,
+                ClientColorsConfig colors,
+                boolean exclusiveRoot,
+                int spentPointsLimit,
+                int levelLimit,
+                Map<String, ExtendedClientSkillDefinitionConfig> definitions,
+                Map<String, ClientSkillConfig> skills,
+                Collection<ClientSkillConnectionConfig> normalConnections,
+                Collection<ClientSkillConnectionConfig> exclusiveConnections,
+                Map<String, Collection<ClientSkillConnectionConfig>> skillNormalConnections,
+                Map<String, Collection<ClientSkillConnectionConfig>> skillExclusiveConnections,
+                Map<String, Collection<String>> skillNormalNeighbors,
+                Map<String, Collection<String>> skillExclusiveNeighbors,
+                Map<String, Collection<String>> skillNormalNeighborsReversed,
+                Map<String, Collection<String>> skillExclusiveNeighborsReversed
+) {
+        public ExtendedClientCategoryConfig(
+                        Identifier id,
+                        Text title,
+                        ClientIconConfig icon,
+                        ExtendedClientBackgroundConfig background,
+                        ClientColorsConfig colors,
+                        boolean exclusiveRoot,
+                        int spentPointsLimit,
+                        int levelLimit,
+                        Map<String, ExtendedClientSkillDefinitionConfig> definitions,
+                        Map<String, ClientSkillConfig> skills,
+                        Collection<ClientSkillConnectionConfig> normalConnections,
+                        Collection<ClientSkillConnectionConfig> exclusiveConnections
+        ) {
+                this(
+                                id,
+                                title,
+                                icon,
+                                background,
+                                colors,
+                                exclusiveRoot,
+                                spentPointsLimit,
+                                levelLimit,
+                                definitions,
+                                skills,
+                                normalConnections,
+                                exclusiveConnections,
+                                new HashMap<>(),
+                                new HashMap<>(),
+                                new HashMap<>(),
+                                new HashMap<>(),
+                                new HashMap<>(),
+                                new HashMap<>()
+                );
+
+                for (var connection : normalConnections) {
+                        var a = connection.skillAId();
+                        var b = connection.skillBId();
+
+                        skillNormalNeighbors.computeIfAbsent(a, key -> new HashSet<>()).add(b);
+                        skillNormalNeighborsReversed.computeIfAbsent(b, key -> new HashSet<>()).add(a);
+                        if (connection.bidirectional()) {
+                                skillNormalNeighbors.computeIfAbsent(b, key -> new HashSet<>()).add(a);
+                                skillNormalNeighborsReversed.computeIfAbsent(a, key -> new HashSet<>()).add(b);
+                        }
+
+                        skillNormalConnections.computeIfAbsent(a, key -> new HashSet<>()).add(connection);
+                        skillNormalConnections.computeIfAbsent(b, key -> new HashSet<>()).add(connection);
+                }
+
+                for (var connection : exclusiveConnections) {
+                        var a = connection.skillAId();
+                        var b = connection.skillBId();
+
+                        skillExclusiveNeighbors.computeIfAbsent(a, key -> new HashSet<>()).add(b);
+                        skillExclusiveNeighborsReversed.computeIfAbsent(b, key -> new HashSet<>()).add(a);
+                        if (connection.bidirectional()) {
+                                skillExclusiveNeighbors.computeIfAbsent(b, key -> new HashSet<>()).add(a);
+                                skillExclusiveNeighborsReversed.computeIfAbsent(a, key -> new HashSet<>()).add(b);
+                        }
+
+                        this.skillExclusiveConnections.computeIfAbsent(a, key -> new HashSet<>()).add(connection);
+                        this.skillExclusiveConnections.computeIfAbsent(b, key -> new HashSet<>()).add(connection);
+                }
+        }
+
+        public Bounds2i getBounds() {
+                var bounds = Bounds2i.zero();
+                for (var skill : skills.values()) {
+                        bounds.extend(new Vector2i(skill.x(), skill.y()));
+                }
+                return bounds;
+        }
+
+        public Optional<ExtendedClientSkillDefinitionConfig> getDefinitionById(String id) {
+                return Optional.ofNullable(definitions.get(id));
+        }
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/config/skill/ExtendedClientSkillDefinitionConfig.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/config/skill/ExtendedClientSkillDefinitionConfig.java
@@ -1,0 +1,30 @@
+package net.bluelotuscoding.puffishskillleveling.client.config.skill;
+
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.client.config.ClientFrameConfig;
+import net.puffish.skillsmod.client.config.ClientIconConfig;
+
+/**
+ * Holds extended skill definition information sent by the server. This mirrors
+ * {@link net.puffish.skillsmod.client.config.skill.ClientSkillDefinitionConfig}
+ * but adds additional fields used by the skill leveling addon.
+ */
+public record ExtendedClientSkillDefinitionConfig(
+                String id,
+                Identifier type,
+                int maxLevels,
+                java.util.List<Text> descriptions,
+                java.util.List<Text> extraDescriptions,
+                Text title,
+                ClientIconConfig icon,
+                ClientFrameConfig frame,
+                float size,
+                boolean mergeDescription,
+                int cost,
+                int requiredSkills,
+                int requiredPoints,
+                int requiredSpentPoints,
+                int requiredExclusions,
+                boolean hasLevelRewards
+) { }

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/data/ExtendedClientCategoryData.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/data/ExtendedClientCategoryData.java
@@ -1,0 +1,452 @@
+package net.bluelotuscoding.puffishskillleveling.client.data;
+
+import net.puffish.skillsmod.client.data.ClientSkillConnectionData;
+import net.puffish.skillsmod.api.Skill;
+import net.bluelotuscoding.puffishskillleveling.client.config.ExtendedClientCategoryConfig;
+import net.puffish.skillsmod.client.config.colors.ClientFillStrokeColorsConfig;
+import net.puffish.skillsmod.client.config.skill.ClientSkillConfig;
+import net.puffish.skillsmod.client.config.skill.ClientSkillConnectionConfig;
+import net.bluelotuscoding.puffishskillleveling.client.config.skill.ExtendedClientSkillDefinitionConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ExtendedClientCategoryData {
+	private final ExtendedClientCategoryConfig config;
+        private final Map<String, Skill.State> skillStates;
+        private final Map<String, Integer> skillLevels;
+        private final Map<ClientSkillConnectionConfig, ClientSkillConnectionData> connectionStates;
+
+	private int spentPoints;
+	private int earnedPoints;
+
+	private int currentLevel;
+	private int currentExperience;
+	private int requiredExperience;
+
+	private float scale = 1;
+
+	private int x = 0;
+	private int y = 0;
+
+	private long lastOpen;
+
+	public ExtendedClientCategoryData(
+			ExtendedClientCategoryConfig config,
+                        Map<String, Skill.State> skillStates,
+                        Map<String, Integer> skillLevels,
+                        int spentPoints,
+                        int earnedPoints,
+                        int currentLevel,
+                        int currentExperience,
+                        int requiredExperience
+        ) {
+                this.config = config;
+                this.skillStates = skillStates;
+                this.skillLevels = new HashMap<>(skillLevels);
+                this.spentPoints = spentPoints;
+                this.earnedPoints = earnedPoints;
+                this.currentLevel = currentLevel;
+                this.currentExperience = currentExperience;
+                this.requiredExperience = requiredExperience;
+                this.connectionStates = new HashMap<>();
+
+		for (var connection : config.normalConnections()) {
+			var skillA = config.skills().get(connection.skillAId());
+			if (skillA == null) {
+				continue;
+			}
+			var skillB = config.skills().get(connection.skillBId());
+			if (skillB == null) {
+				continue;
+			}
+
+			connectionStates.put(connection, new ClientSkillConnectionData(
+					skillA,
+					skillB,
+					getConnectionColor(skillA, skillB, connection.bidirectional())
+			));
+		}
+		for (var connection : config.exclusiveConnections()) {
+			var skillA = config.skills().get(connection.skillAId());
+			if (skillA == null) {
+				continue;
+			}
+			var skillB = config.skills().get(connection.skillBId());
+			if (skillB == null) {
+				continue;
+			}
+
+			connectionStates.put(connection, new ClientSkillConnectionData(
+					skillA,
+					skillB,
+					this.config.colors().connections().excluded()
+			));
+		}
+	}
+
+	private void updateSkillState(ClientSkillConfig skill, Skill.State state) {
+		skillStates.put(skill.id(), state);
+
+		var normalConnections = this.config.skillNormalConnections().get(skill.id());
+		if (normalConnections != null) {
+			for (var connection : normalConnections) {
+				updateConnection(connection);
+			}
+		}
+	}
+
+	public Skill.State getSkillState(ClientSkillConfig skill) {
+		return skillStates.get(skill.id());
+	}
+
+        public int countUnlocked(String definitionId) {
+                return config.skills()
+                                .values()
+                                .stream()
+                                .filter(skill -> skill.definitionId().equals(definitionId))
+                                .mapToInt(skill -> skillLevels.getOrDefault(skill.id(), 0))
+                                .sum();
+        }
+
+        public int getSkillLevel(String skillId) {
+                return skillLevels.getOrDefault(skillId, 0);
+        }
+
+        public void unlock(String skillId, int level) {
+                var skill = config.skills().get(skillId);
+                if (skill == null) {
+                        return;
+                }
+                skillLevels.put(skillId, level);
+                updateSkillState(skill, Skill.State.UNLOCKED);
+                if (skill.isRoot() && config.exclusiveRoot()) {
+                        config.skills()
+					.values()
+					.stream()
+					.filter(ClientSkillConfig::isRoot)
+					.filter(other -> switch (getSkillState(other)) {
+						case AVAILABLE, AFFORDABLE -> true;
+						default -> false;
+					})
+					.forEach(other -> {
+						if (!isAvailable(other)) {
+							updateSkillState(other, Skill.State.LOCKED);
+						}
+					});
+		}
+		var normalNeighborsIds = config.skillNormalNeighbors().get(skillId);
+		if (normalNeighborsIds != null) {
+			normalNeighborsIds.stream()
+					.map(id -> config.skills().get(id))
+					.filter(Objects::nonNull)
+					.filter(neighbor -> getSkillState(neighbor) == Skill.State.LOCKED)
+					.forEach(neighbor -> {
+						if (isAvailable(neighbor)) {
+							if (isAffordable(neighbor)) {
+								updateSkillState(neighbor, Skill.State.AFFORDABLE);
+							} else {
+								updateSkillState(neighbor, Skill.State.AVAILABLE);
+							}
+						}
+					});
+		}
+		var exclusiveNeighborsIds = config.skillExclusiveNeighbors().get(skillId);
+		if (exclusiveNeighborsIds != null) {
+			exclusiveNeighborsIds.stream()
+					.map(id -> config.skills().get(id))
+					.filter(Objects::nonNull)
+					.filter(neighbor -> getSkillState(neighbor) != Skill.State.UNLOCKED)
+					.forEach(neighbor -> {
+						if (isExcluded(neighbor)) {
+							updateSkillState(neighbor, Skill.State.EXCLUDED);
+						}
+					});
+		}
+	}
+
+        public void lock(String skillId) {
+                var skill = config.skills().get(skillId);
+                if (skill == null) {
+                        return;
+                }
+                skillLevels.remove(skillId);
+                if (isExcluded(skill)) {
+                        updateSkillState(skill, Skill.State.EXCLUDED);
+                } else if (isAvailable(skill)) {
+			if (isAffordable(skill)) {
+				updateSkillState(skill, Skill.State.AFFORDABLE);
+			} else {
+				updateSkillState(skill, Skill.State.AVAILABLE);
+			}
+		} else {
+			updateSkillState(skill, Skill.State.LOCKED);
+		}
+		if (skill.isRoot()) {
+			if (config.exclusiveRoot()) {
+				if (config.skills()
+						.values()
+						.stream()
+						.filter(ClientSkillConfig::isRoot)
+						.allMatch(other -> getSkillState(other) != Skill.State.UNLOCKED)) {
+					config.skills()
+							.values()
+							.stream()
+							.filter(ClientSkillConfig::isRoot)
+							.filter(other -> getSkillState(other) == Skill.State.LOCKED)
+							.forEach(other -> {
+								if (isAffordable(other)) {
+									updateSkillState(other, Skill.State.AFFORDABLE);
+								} else {
+									updateSkillState(other, Skill.State.AVAILABLE);
+								}
+							});
+				}
+			}
+		}
+		var normalNeighborsIds = config.skillNormalNeighbors().get(skillId);
+		if (normalNeighborsIds != null) {
+			normalNeighborsIds.stream()
+					.map(id -> config.skills().get(id))
+					.filter(Objects::nonNull)
+					.filter(neighbor -> switch (getSkillState(neighbor)) {
+						case AVAILABLE, AFFORDABLE -> true;
+						default -> false;
+					})
+					.forEach(neighbor -> {
+						if (!isAvailable(neighbor)) {
+							updateSkillState(neighbor, Skill.State.LOCKED);
+						}
+					});
+		}
+		var exclusiveNeighborsIds = config.skillExclusiveNeighbors().get(skillId);
+		if (exclusiveNeighborsIds != null) {
+			exclusiveNeighborsIds.stream()
+					.map(id -> config.skills().get(id))
+					.filter(Objects::nonNull)
+					.filter(neighbor -> getSkillState(neighbor) == Skill.State.EXCLUDED)
+					.forEach(neighbor -> {
+						if (!isExcluded(neighbor)) {
+							if (isAvailable(neighbor)) {
+								if (isAffordable(neighbor)) {
+									updateSkillState(neighbor, Skill.State.AFFORDABLE);
+								} else {
+									updateSkillState(neighbor, Skill.State.AVAILABLE);
+								}
+							} else {
+								updateSkillState(neighbor, Skill.State.LOCKED);
+							}
+						}
+					});
+		}
+	}
+
+	private boolean isExcluded(ClientSkillConfig skill) {
+		var exclusiveNeighborsReversedIds = config.skillExclusiveNeighborsReversed().get(skill.id());
+		if (exclusiveNeighborsReversedIds == null) {
+			return false;
+		}
+		return config.getDefinitionById(skill.definitionId())
+				.map(definition -> exclusiveNeighborsReversedIds.stream()
+					.map(id -> config.skills().get(id))
+					.filter(Objects::nonNull)
+					.filter(neighbor -> getSkillState(neighbor) == Skill.State.UNLOCKED)
+					.count() >= definition.requiredExclusions()
+				)
+				.orElse(false);
+	}
+
+	private boolean isAvailable(ClientSkillConfig skill) {
+		var normalNeighborsReversedIds = config.skillNormalNeighborsReversed().get(skill.id());
+		if (normalNeighborsReversedIds != null) {
+			if (config.getDefinitionById(skill.definitionId())
+					.map(definition -> normalNeighborsReversedIds.stream()
+							.map(id -> config.skills().get(id))
+							.filter(Objects::nonNull)
+							.filter(neighbor -> getSkillState(neighbor) == Skill.State.UNLOCKED)
+							.count() >= definition.requiredSkills()
+					)
+					.orElse(false)) {
+				return true;
+			}
+		}
+		if (skill.isRoot()) {
+			return !config.exclusiveRoot() || config.skills()
+					.values()
+					.stream()
+					.filter(ClientSkillConfig::isRoot)
+					.allMatch(other -> getSkillState(other) != Skill.State.UNLOCKED);
+		}
+		return false;
+	}
+
+	private boolean isAffordable(ClientSkillConfig skill) {
+		return config.getDefinitionById(skill.definitionId()).map(this::isAffordable).orElse(false);
+	}
+
+	private boolean isAffordable(ExtendedClientSkillDefinitionConfig definition) {
+		return getPointsLeft() >= Math.max(definition.requiredPoints(), definition.cost())
+				&& spentPoints >= definition.requiredSpentPoints();
+	}
+
+	public boolean hasAnySkillLeft() {
+		return config.skills()
+				.values()
+				.stream()
+				.map(this::getSkillState)
+				.anyMatch(state -> state == Skill.State.AVAILABLE || state == Skill.State.AFFORDABLE);
+	}
+
+	public void updatePoints(int spentPoints, int earnedPoints) {
+		this.spentPoints = spentPoints;
+		this.earnedPoints = earnedPoints;
+
+		config.skills()
+				.values()
+				.stream()
+				.filter(skill -> switch (getSkillState(skill)) {
+					case AVAILABLE, AFFORDABLE -> true;
+					default -> false;
+				})
+				.forEach(skill -> {
+					if (isAffordable(skill)) {
+						updateSkillState(skill, Skill.State.AFFORDABLE);
+					} else {
+						updateSkillState(skill, Skill.State.AVAILABLE);
+					}
+				});
+	}
+
+	private void updateConnection(ClientSkillConnectionConfig connection) {
+		var data = connectionStates.get(connection);
+		if (data == null) {
+			return;
+		}
+
+		data.setColor(getConnectionColor(data.getSkillA(), data.getSkillB(), connection.bidirectional()));
+	}
+
+	private static final int[][][] ORDER = {
+			{
+					{0, 0, 0, 0, 0},
+					{0, 0, 0, 0, 0},
+					{0, 0, 0, 0, 0},
+					{0, 1, 2, 3, 0},
+					{0, 0, 0, 0, 0}
+			},
+			{
+					{0, 0, 0, 0, 0},
+					{0, 0, 0, 1, 0},
+					{0, 0, 0, 2, 0},
+					{0, 1, 2, 3, 0},
+					{0, 0, 0, 0, 0}
+			}
+	};
+
+	private ClientFillStrokeColorsConfig getConnectionColor(ClientSkillConfig skillA, ClientSkillConfig skillB, boolean bidirectional) {
+		return switch (ORDER
+				[bidirectional ? 1 : 0]
+				[getSkillState(skillA).ordinal()]
+				[getSkillState(skillB).ordinal()]
+		) {
+			case 3 -> config.colors().connections().unlocked();
+			case 2 -> config.colors().connections().affordable();
+			case 1 -> config.colors().connections().available();
+			default -> config.colors().connections().locked();
+		};
+	}
+
+	public Optional<ClientSkillConnectionData> getConnection(ClientSkillConnectionConfig connection) {
+		return Optional.ofNullable(connectionStates.get(connection));
+	}
+
+	public ExtendedClientCategoryConfig getConfig() {
+		return config;
+	}
+
+	public int getPointsLeft() {
+		return Math.max(Math.min(earnedPoints, config.spentPointsLimit()) - spentPoints, 0);
+	}
+
+	public int getSpentPoints() {
+		return spentPoints;
+	}
+
+	public int getEarnedPoints() {
+		return earnedPoints;
+	}
+
+	public int getSpentPointsLeft() {
+		return Math.max(config.spentPointsLimit() - spentPoints, 0);
+	}
+
+	public int getCurrentLevel() {
+		return currentLevel;
+	}
+
+	public boolean hasExperience() {
+		return currentLevel >= 0;
+	}
+
+	public void setCurrentLevel(int currentLevel) {
+		this.currentLevel = currentLevel;
+	}
+
+	public int getCurrentExperience() {
+		return currentExperience;
+	}
+
+	public void setCurrentExperience(int currentExperience) {
+		this.currentExperience = currentExperience;
+	}
+
+	public int getRequiredExperience() {
+		return requiredExperience;
+	}
+
+	public void setRequiredExperience(int requiredExperience) {
+		this.requiredExperience = requiredExperience;
+	}
+
+	public float getExperienceProgress() {
+		return ((float) currentExperience) / ((float) requiredExperience);
+	}
+
+	public int getExperienceToNextLevel() {
+		return requiredExperience - currentExperience;
+	}
+
+	public float getScale() {
+		return scale;
+	}
+
+	public void setScale(float scale) {
+		this.scale = scale;
+	}
+
+	public int getX() {
+		return x;
+	}
+
+	public void setX(int x) {
+		this.x = x;
+	}
+
+	public int getY() {
+		return y;
+	}
+
+	public void setY(int y) {
+		this.y = y;
+	}
+
+	public long getLastOpen() {
+		return lastOpen;
+	}
+
+	public void updateLastOpen() {
+		this.lastOpen = System.currentTimeMillis();
+	}
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/data/ExtendedClientSkillScreenData.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/data/ExtendedClientSkillScreenData.java
@@ -1,0 +1,46 @@
+package net.bluelotuscoding.puffishskillleveling.client.data;
+
+import net.minecraft.util.Identifier;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ExtendedClientSkillScreenData {
+	private final Map<Identifier, ExtendedClientCategoryData> categories = new LinkedHashMap<>();
+
+	private int offset = 0;
+
+	public void putCategory(Identifier categoryId, ExtendedClientCategoryData categoryData) {
+		categories.put(categoryId, categoryData);
+	}
+
+	public void removeCategory(Identifier categoryId) {
+		categories.remove(categoryId);
+	}
+
+	public void clearCategories() {
+		categories.clear();
+	}
+
+	public Optional<ExtendedClientCategoryData> getCategory(Identifier categoryId) {
+		return Optional.ofNullable(categories.get(categoryId));
+	}
+
+	public Collection<ExtendedClientCategoryData> getCategories() {
+		return categories.values();
+	}
+
+	public int getOffset() {
+		return offset;
+	}
+
+	public void incrementOffset() {
+		this.offset++;
+	}
+
+	public void decrementOffset() {
+		this.offset--;
+	}
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/gui/ExtendedSkillsScreen.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/gui/ExtendedSkillsScreen.java
@@ -1,0 +1,1176 @@
+package net.bluelotuscoding.puffishskillleveling.client.gui;
+
+import net.bluelotuscoding.puffishskillleveling.client.ExtendedSkillsClientMod;
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.advancement.AdvancementObtainedStatus;
+import net.minecraft.client.gui.tooltip.Tooltip;
+import net.minecraft.client.gui.widget.ToggleButtonWidget;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.OrderedText;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.text.Texts;
+import net.minecraft.text.MutableText;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.Skill;
+import net.bluelotuscoding.puffishskillleveling.client.config.ExtendedClientBackgroundConfig;
+import net.puffish.skillsmod.client.config.ClientFrameConfig;
+import net.puffish.skillsmod.client.config.ClientIconConfig;
+import net.puffish.skillsmod.client.config.skill.ClientSkillConfig;
+import net.bluelotuscoding.puffishskillleveling.client.config.skill.ExtendedClientSkillDefinitionConfig;
+import net.bluelotuscoding.puffishskillleveling.client.data.ExtendedClientCategoryData;
+import net.bluelotuscoding.puffishskillleveling.client.data.ExtendedClientSkillScreenData;
+import net.puffish.skillsmod.client.network.packets.out.SkillClickOutPacket;
+import net.puffish.skillsmod.client.rendering.ConnectionBatchedRenderer;
+import net.puffish.skillsmod.client.rendering.ItemBatchedRenderer;
+import net.puffish.skillsmod.client.rendering.TextureBatchedRenderer;
+import net.puffish.skillsmod.common.BackgroundPosition;
+import net.puffish.skillsmod.util.Bounds2i;
+import org.joml.Vector2i;
+import org.joml.Vector4f;
+import org.joml.Vector4fc;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+public class ExtendedSkillsScreen extends Screen {
+	private static final Identifier TABS_TEXTURE = new Identifier("textures/gui/advancements/tabs.png");
+	private static final Identifier WINDOW_TEXTURE = new Identifier("textures/gui/advancements/window.png");
+	private static final Identifier WIDGETS_TEXTURE = new Identifier("textures/gui/advancements/widgets.png");
+	private static final Identifier ICONS_TEXTURE = new Identifier("textures/gui/icons.png");
+	private static final Identifier RECIPE_BOOK_TEXTURE = new Identifier("textures/gui/recipe_book.png");
+
+	private static final int TEXTURE_WIDTH = 256;
+	private static final int TEXTURE_HEIGHT = 256;
+	private static final int FRAME_WIDTH = 252;
+	private static final int FRAME_HEIGHT = 140;
+	private static final int FRAME_PADDING = 8;
+	private static final int FRAME_CUT = 16;
+	private static final int FRAME_EXPAND = 24;
+	private static final int CONTENT_GROW = 32;
+	private static final int TABS_HEIGHT = 28;
+	private static final int HALF_FRAME_WIDTH = FRAME_WIDTH / 2;
+	private static final int HALF_FRAME_HEIGHT = FRAME_HEIGHT / 2;
+
+	private static final Vector4fc COLOR_WHITE = new Vector4f(1f, 1f, 1f, 1f);
+	private static final Vector4fc COLOR_GRAY = new Vector4f(0.25f, 0.25f, 0.25f, 1f);
+
+	private final ExtendedClientSkillScreenData data;
+
+	private Optional<ExtendedClientCategoryData> optActiveCategoryData = Optional.empty();
+
+	private Optional<Identifier> optActiveCategoryId;
+
+	private ToggleButtonWidget nextButton;
+	private ToggleButtonWidget prevButton;
+
+	private float minScale = 1f;
+	private float maxScale = 1f;
+
+	private double dragStartX = 0;
+	private double dragStartY = 0;
+	private double dragTotal = 0;
+	private boolean canDrag = false;
+
+	private Bounds2i bounds = Bounds2i.zero();
+	private boolean small = false;
+
+	private int contentPaddingTop = 0;
+	private int contentPaddingLeft = 0;
+	private int contentPaddingRight = 0;
+	private int contentPaddingBottom = 0;
+
+	public ExtendedSkillsScreen(ExtendedClientSkillScreenData data, Optional<Identifier> optCategoryId) {
+		super(ScreenTexts.EMPTY);
+		this.data = data;
+		optActiveCategoryId = optCategoryId;
+	}
+
+	@Override
+	protected void init() {
+		super.init();
+		resize();
+	}
+
+	private void resize() {
+		this.small = optActiveCategoryData
+				.map(activeCategoryData -> activeCategoryData.hasExperience() && this.width < 450)
+				.orElse(false);
+
+		if (this.small) {
+			contentPaddingTop = 62;
+			contentPaddingLeft = 17;
+			contentPaddingRight = 17;
+			contentPaddingBottom = 17;
+		} else {
+			contentPaddingTop = 54;
+			contentPaddingLeft = 17;
+			contentPaddingRight = 17;
+			contentPaddingBottom = 17;
+		}
+
+		var halfWidth = this.width / 2;
+		var halfHeight = this.height / 2;
+
+		this.bounds = optActiveCategoryData
+				.map(activeCategoryData -> activeCategoryData.getConfig().getBounds())
+				.orElseGet(Bounds2i::zero);
+		this.bounds.grow(CONTENT_GROW);
+		this.bounds.extend(new Vector2i(contentPaddingLeft - halfWidth, contentPaddingTop - halfHeight));
+		this.bounds.extend(new Vector2i(this.width - halfWidth - contentPaddingRight, this.height - halfHeight - contentPaddingBottom));
+
+		var contentWidth = this.width - contentPaddingLeft - contentPaddingRight;
+		var contentHeight = this.height - contentPaddingTop - contentPaddingBottom;
+
+		var halfContentWidth = MathHelper.ceilDiv(this.bounds.height() * contentWidth, contentHeight * 2);
+		var halfContentHeight = MathHelper.ceilDiv(this.bounds.width() * contentHeight, contentWidth * 2);
+
+		this.bounds.extend(new Vector2i(-halfContentWidth, -halfContentHeight));
+		this.bounds.extend(new Vector2i(halfContentWidth, halfContentHeight));
+
+		this.minScale = Math.max(
+				((float) contentWidth) / ((float) this.bounds.width()),
+				((float) contentHeight) / ((float) this.bounds.height())
+		);
+		this.maxScale = 1f;
+
+		this.nextButton = new ToggleButtonWidget(this.width - FRAME_PADDING - 12, FRAME_PADDING + 8, 12, 17, false) {
+			@Override
+			public void onClick(double mouseX, double mouseY) {
+				data.incrementOffset();
+			}
+		};
+		this.nextButton.setTextureUV(1, 208, 13, 18, RECIPE_BOOK_TEXTURE);
+		this.prevButton = new ToggleButtonWidget(FRAME_PADDING, FRAME_PADDING + 8, 12, 17, true) {
+			@Override
+			public void onClick(double mouseX, double mouseY) {
+				data.decrementOffset();
+			}
+		};
+		this.prevButton.setTextureUV(1, 208, 13, 18, RECIPE_BOOK_TEXTURE);
+	}
+
+	private Vector2i getMousePos(double mouseX, double mouseY) {
+		return new Vector2i(
+				(int) mouseX,
+				(int) mouseY
+		);
+	}
+
+	private Vector2i getTransformedMousePos(double mouseX, double mouseY, ExtendedClientCategoryData activeCategoryData) {
+		return new Vector2i(
+				(int) Math.round((mouseX - activeCategoryData.getX() - width / 2.0) / activeCategoryData.getScale()),
+				(int) Math.round((mouseY - activeCategoryData.getY() - height / 2.0) / activeCategoryData.getScale())
+		);
+	}
+
+	private boolean isInsideTab(Vector2i mouse, int x) {
+		return mouse.x >= x && mouse.y >= FRAME_PADDING && mouse.x < x + 28 && mouse.y < FRAME_PADDING + 32;
+	}
+
+	private boolean isInsideSkill(Vector2i transformedMouse, ClientSkillConfig skill, ExtendedClientSkillDefinitionConfig definition) {
+		var halfSize = Math.round(13f * definition.size());
+		return transformedMouse.x >= skill.x() - halfSize && transformedMouse.y >= skill.y() - halfSize && transformedMouse.x < skill.x() + halfSize && transformedMouse.y < skill.y() + halfSize;
+	}
+
+	private boolean isInsideContent(Vector2i mouse) {
+		return mouse.x >= contentPaddingLeft && mouse.y >= contentPaddingTop && mouse.x < width - contentPaddingRight && mouse.y < height - contentPaddingBottom;
+	}
+
+	private boolean isInsideExperience(Vector2i mouse, int x, int y) {
+		return mouse.x >= x && mouse.y >= y && mouse.x < x + 182 && mouse.y < y + 5;
+	}
+
+	private boolean isInsideArea(Vector2i mouse, int x1, int y1, int x2, int y2) {
+		return mouse.x >= x1 && mouse.y >= y1 && mouse.x < x2 && mouse.y < y2;
+	}
+
+	private void syncCategory() {
+		var opt = optActiveCategoryId.flatMap(data::getCategory);
+		opt.ifPresent(ExtendedClientCategoryData::updateLastOpen);
+		if (optActiveCategoryData.isEmpty() || optActiveCategoryData.orElseThrow() != opt.orElse(null)) {
+			optActiveCategoryData = data.getCategories()
+					.stream()
+					.max(Comparator.comparing(ExtendedClientCategoryData::getLastOpen));
+			resize();
+		}
+	}
+
+	private int getTabX(int i) {
+		return FRAME_PADDING + (i - data.getOffset()) * 32 + (data.getOffset() > 0 ? (12 + 3) : 0);
+	}
+
+	private void forEachVisibleTab(BiConsumer<Integer, ExtendedClientCategoryData> consumer) {
+		var it = data.getCategories().iterator();
+		var i = 0;
+		while (it.hasNext()) {
+			var category = it.next();
+			var x = getTabX(i);
+			if (x >= FRAME_PADDING && x + 28 <= this.width - FRAME_PADDING - 12 - 3) {
+				consumer.accept(x, category);
+			}
+			i++;
+		}
+	}
+
+	private boolean hasNextButton() {
+		var x = getTabX(data.getCategories().size() - 1);
+		return x + 28 > this.width - FRAME_PADDING - 12 - 3;
+	}
+
+	private boolean hasPrevButton() {
+		return data.getOffset() > 0;
+	}
+
+	@Override
+	public boolean mouseClicked(double mouseX, double mouseY, int button) {
+		if (button == GLFW.GLFW_MOUSE_BUTTON_1) {
+			optActiveCategoryData.ifPresent(activeCategoryData ->
+					mouseClickedWithCategory(mouseX, mouseY, activeCategoryData)
+			);
+		}
+
+		if (hasNextButton()) {
+			nextButton.mouseClicked(mouseX, mouseY, button);
+		}
+		if (hasPrevButton()) {
+			prevButton.mouseClicked(mouseX, mouseY, button);
+		}
+
+		return true;
+	}
+
+	private void mouseClickedWithCategory(double mouseX, double mouseY, ExtendedClientCategoryData activeCategoryData) {
+		var mouse = getMousePos(mouseX, mouseY);
+
+		if (isInsideContent(mouse)) {
+			dragStartX = mouseX - activeCategoryData.getX();
+			dragStartY = mouseY - activeCategoryData.getY();
+			dragTotal = 0;
+			canDrag = true;
+		} else {
+			canDrag = false;
+		}
+
+		forEachVisibleTab((x, category) -> {
+			if (isInsideTab(mouse, x)) {
+				optActiveCategoryId = Optional.ofNullable(category.getConfig().id());
+				syncCategory();
+			}
+		});
+	}
+
+	@Override
+	public boolean mouseReleased(double mouseX, double mouseY, int button) {
+		if (button == GLFW.GLFW_MOUSE_BUTTON_1) {
+			if (dragTotal > 2) {
+				return true;
+			}
+
+			optActiveCategoryData.ifPresent(activeCategoryData ->
+					mouseReleasedWithCategory(mouseX, mouseY, activeCategoryData)
+			);
+		}
+
+		return true;
+	}
+
+	private void mouseReleasedWithCategory(double mouseX, double mouseY, ExtendedClientCategoryData activeCategoryData) {
+		var mouse = getMousePos(mouseX, mouseY);
+		var transformedMouse = getTransformedMousePos(mouseX, mouseY, activeCategoryData);
+		var activeCategory = activeCategoryData.getConfig();
+
+                if (isInsideContent(mouse)) {
+            var stream = activeCategory.skills().values().stream()
+                            .filter(skill -> activeCategory
+                                            .getDefinitionById(skill.definitionId())
+                                            .map(definition -> isInsideSkill(transformedMouse, skill, definition))
+                                            .orElse(false));
+
+            var optSkill = stream
+                            .filter(skill -> activeCategoryData.getSkillState(skill) != Skill.State.UNLOCKED)
+                            .findFirst();
+
+            if (optSkill.isEmpty()) {
+                optSkill = activeCategory.skills().values().stream()
+                                .filter(skill -> activeCategory
+                                                .getDefinitionById(skill.definitionId())
+                                                .map(definition -> isInsideSkill(transformedMouse, skill, definition))
+                                                .orElse(false))
+                                .findFirst();
+            }
+
+            optSkill.ifPresent(skill -> ExtendedSkillsClientMod.getInstance()
+                            .getPacketSender()
+                            .send(new SkillClickOutPacket(activeCategory.id(), skill.id())));
+                }
+        }
+
+	@Override
+	public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+		if (ExtendedSkillsClientMod.OPEN_KEY_BINDING.matchesKey(keyCode, scanCode)) {
+			this.close();
+			return true;
+		}
+		return super.keyPressed(keyCode, scanCode, modifiers);
+	}
+
+	@Override
+	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+		this.syncCategory();
+
+		this.renderBackground(context);
+		this.drawContent(context, mouseX, mouseY);
+		this.drawWindow(context, mouseX, mouseY);
+		this.drawTabs(context, mouseX, mouseY, delta);
+	}
+
+	@Override
+	public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+		if (!canDrag) {
+			return true;
+		}
+
+		if (button == GLFW.GLFW_MOUSE_BUTTON_1) {
+			dragTotal += Math.abs(deltaX);
+			dragTotal += Math.abs(deltaY);
+			if (dragTotal > 2) {
+				optActiveCategoryData.ifPresent(activeCategoryData -> {
+					applyChangesWithLimits(
+							(int) Math.round(mouseX - dragStartX),
+							(int) Math.round(mouseY - dragStartY),
+							activeCategoryData.getScale(),
+							activeCategoryData
+					);
+				});
+			}
+		}
+
+		return true;
+	}
+
+	@Override
+	public boolean mouseScrolled(double mouseX, double mouseY, double amount) {
+		optActiveCategoryData.ifPresent(activeCategoryData -> {
+			var factor = (float) Math.pow(2, amount * 0.25);
+
+			var x = activeCategoryData.getX();
+			var y = activeCategoryData.getY();
+			var scale = activeCategoryData.getScale();
+
+			scale *= factor;
+
+			if (scale < minScale) {
+				scale = minScale;
+				factor = minScale / scale;
+			}
+			if (scale > maxScale) {
+				scale = maxScale;
+				factor = maxScale / scale;
+			}
+
+			applyChangesWithLimits(
+					x - (int) Math.round((factor - 1f) * (mouseX - x - this.width / 2f)),
+					y - (int) Math.round((factor - 1f) * (mouseY - y - this.height / 2f)),
+					scale,
+					activeCategoryData
+			);
+		});
+
+		return super.mouseScrolled(mouseX, mouseY, amount);
+	}
+
+	private void applyChangesWithLimits(int x, int y, float scale, ExtendedClientCategoryData activeCategoryData) {
+		var halfWidth = this.width / 2;
+		var halfHeight = this.height / 2;
+
+		activeCategoryData.setX(MathHelper.clamp(
+				x,
+				(int) Math.ceil(halfWidth - contentPaddingRight - bounds.max().x() * scale),
+				(int) Math.floor(contentPaddingLeft - halfWidth - bounds.min().x() * scale)
+		));
+		activeCategoryData.setY(MathHelper.clamp(
+				y,
+				(int) Math.ceil(halfHeight - contentPaddingBottom - bounds.max().y() * scale),
+				(int) Math.floor(contentPaddingTop - halfHeight - bounds.min().y() * scale)
+		));
+		activeCategoryData.setScale(scale);
+	}
+
+	private void drawIcon(DrawContext context, TextureBatchedRenderer textureRenderer, ItemBatchedRenderer itemRenderer, ClientIconConfig icon, float sizeScale, int x, int y) {
+		if (client == null) {
+			return;
+		}
+
+		var matrices = context.getMatrices();
+		matrices.push();
+
+		if (icon instanceof ClientIconConfig.ItemIconConfig itemIcon) {
+			matrices.translate(x * (1f - sizeScale), y * (1f - sizeScale), 1f);
+			matrices.scale(sizeScale, sizeScale, 1);
+			itemRenderer.emitItem(
+					context,
+					itemIcon.item(),
+					x, y
+			);
+		} else if (icon instanceof ClientIconConfig.EffectIconConfig effectIcon) {
+			matrices.translate(0f, 0f, 1f);
+			var sprite = client.getStatusEffectSpriteManager().getSprite(effectIcon.effect());
+			var halfSize = Math.round(9f * sizeScale);
+			var size = halfSize * 2;
+			textureRenderer.emitSpriteStretch(
+					context, sprite,
+					x - halfSize, y - halfSize, size, size,
+					COLOR_WHITE
+			);
+		} else if (icon instanceof ClientIconConfig.TextureIconConfig textureIcon) {
+			matrices.translate(0f, 0f, 1f);
+			var halfSize = Math.round(8f * sizeScale);
+			var size = halfSize * 2;
+			textureRenderer.emitTexture(
+					context, textureIcon.texture(),
+					x - halfSize, y - halfSize, size, size,
+					COLOR_WHITE
+			);
+		}
+
+		matrices.pop();
+	}
+
+	private void drawFrame(DrawContext context, TextureBatchedRenderer textureRenderer, ClientFrameConfig frame, float sizeScale, int x, int y, Skill.State state) {
+		if (client == null) {
+			return;
+		}
+
+		var halfSize = Math.round(13f * sizeScale);
+		var size = halfSize * 2;
+
+		if (frame instanceof ClientFrameConfig.AdvancementFrameConfig advancementFrame) {
+			var status = state == Skill.State.UNLOCKED ? AdvancementObtainedStatus.OBTAINED : AdvancementObtainedStatus.UNOBTAINED;
+			var color = switch (state) {
+				case LOCKED, EXCLUDED -> COLOR_GRAY;
+				case AVAILABLE, AFFORDABLE, UNLOCKED -> COLOR_WHITE;
+			};
+
+			textureRenderer.emitTexture(
+					context, WIDGETS_TEXTURE,
+					x - halfSize, y - halfSize, size, size,
+					(float) advancementFrame.frame().getTextureV() / TEXTURE_WIDTH,
+					(float) (128 + status.getSpriteIndex() * 26) / TEXTURE_HEIGHT,
+					(float) (advancementFrame.frame().getTextureV() + 26) / TEXTURE_WIDTH,
+					(float) (128 + status.getSpriteIndex() * 26 + 26) / TEXTURE_HEIGHT,
+					color
+			);
+		} else if (frame instanceof ClientFrameConfig.TextureFrameConfig textureFrame) {
+			switch (state) {
+				case LOCKED -> textureFrame.lockedTexture().ifPresentOrElse(
+						lockedTexture -> textureRenderer.emitTexture(
+								context, lockedTexture,
+								x - halfSize, y - halfSize, size, size,
+								COLOR_WHITE
+						),
+						() -> textureRenderer.emitTexture(
+								context, textureFrame.availableTexture(),
+								x - halfSize, y - halfSize, size, size,
+								COLOR_GRAY
+						)
+				);
+				case AVAILABLE -> textureRenderer.emitTexture(
+						context, textureFrame.availableTexture(),
+						x - halfSize, y - halfSize, size, size,
+						COLOR_WHITE
+				);
+				case AFFORDABLE -> textureFrame.affordableTexture().ifPresentOrElse(
+						affordableTexture -> textureRenderer.emitTexture(
+								context, affordableTexture,
+								x - halfSize, y - halfSize, size, size,
+								COLOR_WHITE
+						),
+						() -> textureRenderer.emitTexture(
+								context, textureFrame.availableTexture(),
+								x - halfSize, y - halfSize, size, size,
+								COLOR_WHITE
+						)
+				);
+				case UNLOCKED -> textureRenderer.emitTexture(
+						context, textureFrame.unlockedTexture(),
+						x - halfSize, y - halfSize, size, size,
+						COLOR_WHITE
+				);
+				case EXCLUDED -> textureFrame.excludedTexture().ifPresentOrElse(
+						excludedTexture -> textureRenderer.emitTexture(
+								context, excludedTexture,
+								x - halfSize, y - halfSize, size, size,
+								COLOR_WHITE
+						), () -> textureRenderer.emitTexture(
+								context, textureFrame.availableTexture(),
+								x - halfSize, y - halfSize, size, size,
+								COLOR_GRAY
+						)
+				);
+				default -> throw new UnsupportedOperationException();
+			}
+		}
+	}
+
+	private void drawBackground(DrawContext context, ExtendedClientBackgroundConfig background) {
+		var position = background.position();
+
+		switch (position) {
+			case TILE -> {
+				context.drawTexture(
+						background.texture(),
+						bounds.min().x(),
+						bounds.min().y(),
+						0,
+						0,
+						bounds.width(),
+						bounds.height(),
+						background.width(),
+						background.height()
+				);
+				return;
+			}
+			case FILL -> {
+				if (bounds.width() * background.height() > background.width() * bounds.height()) {
+					position = BackgroundPosition.FILL_WIDTH;
+				} else {
+					position = BackgroundPosition.FILL_HEIGHT;
+				}
+			}
+			default -> { }
+		}
+
+		int x;
+		int y;
+		int width;
+		int height;
+
+		switch (position) {
+			case NONE -> {
+				width = background.width();
+				height = background.height();
+				x = width / -2;
+				y = height / -2;
+			}
+			case FILL_WIDTH -> {
+				x = bounds.min().x();
+				width = bounds.width();
+				y = -MathHelper.ceilDiv(background.height() * width, 2 * background.width());
+				height = -2 * y;
+			}
+			case FILL_HEIGHT -> {
+				y = bounds.min().y();
+				height = bounds.height();
+				x = -MathHelper.ceilDiv(background.width() * height, 2 * background.height());
+				width = -2 * x;
+			}
+			default -> throw new IllegalStateException();
+		}
+
+		context.drawTexture(
+				background.texture(),
+				x,
+				y,
+				0,
+				0,
+				width,
+				height,
+				width,
+				height
+		);
+	}
+
+	private void drawContent(DrawContext context, double mouseX, double mouseY) {
+		RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+		RenderSystem.colorMask(true, true, true, true);
+		RenderSystem.disableBlend();
+		RenderSystem.enableDepthTest();
+
+		context.enableScissor(
+				contentPaddingLeft - 4,
+				contentPaddingTop - 4,
+				this.width - contentPaddingRight + 4,
+				this.height - contentPaddingBottom + 4
+		);
+
+		context.fill(0, 0, width, height, 0xff000000);
+
+		optActiveCategoryData.ifPresentOrElse(
+				activeCategoryData -> drawContentWithCategory(context, mouseX, mouseY, activeCategoryData),
+				() -> drawContentWithoutCategory(context)
+		);
+
+		context.disableScissor();
+	}
+
+	private void drawContentWithCategory(DrawContext context, double mouseX, double mouseY, ExtendedClientCategoryData activeCategoryData) {
+		if (client == null) {
+			return;
+		}
+
+		var mouse = getMousePos(mouseX, mouseY);
+		var transformedMouse = getTransformedMousePos(mouseX, mouseY, activeCategoryData);
+		var activeCategory = activeCategoryData.getConfig();
+
+		var matrices = context.getMatrices();
+		matrices.push();
+
+		matrices.translate(activeCategoryData.getX() + this.width / 2f, activeCategoryData.getY() + this.height / 2f, 0f);
+		matrices.scale(activeCategoryData.getScale(), activeCategoryData.getScale(), 1f);
+
+		drawBackground(context, activeCategory.background());
+
+		var connectionRenderer = new ConnectionBatchedRenderer();
+
+		for (var connection : activeCategory.normalConnections()) {
+			activeCategoryData.getConnection(connection)
+					.ifPresent(relation -> connectionRenderer.emitConnection(
+							context,
+							relation.getSkillA().x(),
+							relation.getSkillA().y(),
+							relation.getSkillB().x(),
+							relation.getSkillB().y(),
+							connection.bidirectional(),
+							relation.getColor().fill().argb(),
+							relation.getColor().stroke().argb()
+					));
+		}
+
+		if (isInsideContent(mouse)) {
+			var optHoveredSkill = activeCategory
+					.skills()
+					.values()
+					.stream()
+					.filter(skill -> activeCategory
+							.getDefinitionById(skill.definitionId())
+							.map(definition -> isInsideSkill(transformedMouse, skill, definition))
+							.orElse(false)
+					)
+					.findFirst();
+
+			optHoveredSkill.ifPresent(hoveredSkill -> {
+				var definition = activeCategory.definitions().get(hoveredSkill.definitionId());
+				if (definition == null) {
+					return;
+				}
+
+				var lines = new ArrayList<OrderedText>();
+				lines.add(definition.title().asOrderedText());
+
+                                var level = activeCategoryData.getSkillLevel(hoveredSkill.id());
+                                if (definition.hasLevelRewards()) {
+                                        lines.add(SkillsMod.createTranslatable(
+                                                        "tooltip",
+                                                        "skill_level",
+                                                        level,
+                                                        definition.maxLevels()
+                                        ).asOrderedText());
+                                }
+                                var descIndex = Math.min(Math.max(level - 1, 0), definition.descriptions().size() - 1);
+                                MutableText desc = Text.empty();
+                                if (!definition.descriptions().isEmpty()) {
+                                        if (definition.mergeDescription() && level > 1) {
+                                                for (int i = 0; i <= descIndex; i++) {
+                                                        if (i > 0) {
+                                                                desc.append(Text.literal("\n"));
+                                                        }
+                                                        desc.append(definition.descriptions().get(i).copy());
+                                                }
+                                        } else {
+                                                desc = definition.descriptions().get(descIndex).copy();
+                                        }
+                                }
+                                lines.addAll(Tooltip.wrapLines(client, Texts.setStyleIfAbsent(
+                                                desc,
+                                                Style.EMPTY.withFormatting(Formatting.GRAY)
+                                )));
+                                if (Screen.hasShiftDown()) {
+                                        var extraIndex = Math.min(Math.max(level - 1, 0), definition.extraDescriptions().size() - 1);
+                                        MutableText extraDesc = Text.empty();
+                                        if (!definition.extraDescriptions().isEmpty()) {
+                                                if (definition.mergeDescription() && level > 1) {
+                                                        for (int i = 0; i <= extraIndex; i++) {
+                                                                if (i > 0) {
+                                                                        extraDesc.append(Text.literal("\n"));
+                                                                }
+                                                                extraDesc.append(definition.extraDescriptions().get(i).copy());
+                                                        }
+                                                } else {
+                                                        extraDesc = definition.extraDescriptions().get(extraIndex).copy();
+                                                }
+                                        }
+                                        lines.addAll(Tooltip.wrapLines(client, Texts.setStyleIfAbsent(
+                                                        extraDesc,
+                                                        Style.EMPTY.withFormatting(Formatting.GRAY)
+                                        )));
+                                }
+
+				if (client.options.advancedItemTooltips) {
+					lines.add(Text.literal(hoveredSkill.id()).formatted(Formatting.DARK_GRAY).asOrderedText());
+				}
+				setTooltip(lines);
+
+				var connections = activeCategory.skillExclusiveConnections().get(hoveredSkill.id());
+				if (connections != null) {
+					for (var connection : connections) {
+						activeCategoryData.getConnection(connection)
+								.ifPresent(relation -> connectionRenderer.emitConnection(
+										context,
+										relation.getSkillA().x(),
+										relation.getSkillA().y(),
+										relation.getSkillB().x(),
+										relation.getSkillB().y(),
+										connection.bidirectional(),
+										relation.getColor().fill().argb(),
+										relation.getColor().stroke().argb()
+								));
+					}
+				}
+			});
+		}
+
+		context.draw();
+
+		RenderSystem.enableBlend();
+		RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
+		connectionRenderer.draw();
+
+		var textureRenderer = new TextureBatchedRenderer();
+		var itemRenderer = new ItemBatchedRenderer();
+
+		for (var skill : activeCategory.skills().values()) {
+			activeCategory
+					.getDefinitionById(skill.definitionId())
+					.ifPresent(definition -> {
+						drawFrame(
+								context,
+								textureRenderer,
+								definition.frame(),
+								definition.size(),
+								skill.x(),
+								skill.y(),
+								activeCategoryData.getSkillState(skill)
+						);
+						drawIcon(
+								context,
+								textureRenderer,
+								itemRenderer,
+								definition.icon(),
+								definition.size(),
+								skill.x(),
+								skill.y()
+						);
+					});
+		}
+
+		textureRenderer.draw();
+		itemRenderer.draw();
+
+		matrices.pop();
+	}
+
+	private void drawContentWithoutCategory(DrawContext context) {
+		var tmpX = contentPaddingLeft + (width - contentPaddingLeft - contentPaddingRight) / 2;
+
+		context.drawCenteredTextWithShadow(
+				this.textRenderer,
+				Text.translatable("advancements.sad_label"),
+				tmpX,
+				height - contentPaddingBottom - this.textRenderer.fontHeight,
+				0xffffffff
+		);
+		context.drawCenteredTextWithShadow(
+				this.textRenderer,
+				Text.translatable("advancements.empty"),
+				tmpX,
+				contentPaddingTop + (height - contentPaddingTop - contentPaddingBottom - this.textRenderer.fontHeight) / 2,
+				0xffffffff
+		);
+	}
+
+	private void drawTabs(DrawContext context, int mouseX, int mouseY, float delta) {
+		if (client == null) {
+			return;
+		}
+
+		if (hasNextButton()) {
+			nextButton.render(context, mouseX, mouseY, delta);
+		}
+		if (hasPrevButton()) {
+			prevButton.render(context, mouseX, mouseY, delta);
+		}
+
+		RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+		RenderSystem.colorMask(true, true, true, true);
+		RenderSystem.setShader(GameRenderer::getPositionTexProgram);
+		RenderSystem.enableBlend();
+		RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
+		RenderSystem.disableDepthTest();
+
+		forEachVisibleTab((x, category) -> context.drawTexture(
+				TABS_TEXTURE,
+				x,
+				FRAME_PADDING,
+				x == FRAME_PADDING ? 0 : 28,
+				optActiveCategoryData.orElse(null) == category ? 32 : 0,
+				28,
+				32
+		));
+
+		var mouse = getMousePos(mouseX, mouseY);
+
+		var textureRenderer = new TextureBatchedRenderer();
+		var itemBatch = new ItemBatchedRenderer();
+
+		forEachVisibleTab((x, category) -> {
+			var categoryConfig = category.getConfig();
+
+			drawIcon(
+					context,
+					textureRenderer,
+					itemBatch,
+					categoryConfig.icon(),
+					1f,
+					x + 6 + 8,
+					FRAME_PADDING + 9 + 8
+			);
+
+			if (isInsideTab(mouse, x)) {
+				var lines = new ArrayList<OrderedText>();
+				lines.add(categoryConfig.title().asOrderedText());
+				if (client.options.advancedItemTooltips) {
+					lines.add(Text.literal(categoryConfig.id().toString()).formatted(Formatting.DARK_GRAY).asOrderedText());
+				}
+				setTooltip(lines);
+			}
+		});
+
+		textureRenderer.draw();
+		itemBatch.draw();
+	}
+
+	private void drawWindow(DrawContext context, double mouseX, double mouseY) {
+		if (client == null) {
+			return;
+		}
+
+		RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+		RenderSystem.colorMask(true, true, true, true);
+		RenderSystem.setShader(GameRenderer::getPositionTexProgram);
+		RenderSystem.enableBlend();
+		RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
+		RenderSystem.disableDepthTest();
+
+		// bottom left
+		context.drawTexture(
+				WINDOW_TEXTURE,
+				FRAME_PADDING,
+				this.height - FRAME_PADDING - HALF_FRAME_HEIGHT,
+				0,
+				HALF_FRAME_HEIGHT,
+				HALF_FRAME_WIDTH,
+				HALF_FRAME_HEIGHT,
+				TEXTURE_WIDTH,
+				TEXTURE_HEIGHT
+		);
+
+		// bottom right
+		context.drawTexture(
+				WINDOW_TEXTURE,
+				this.width - FRAME_PADDING - HALF_FRAME_WIDTH,
+				this.height - FRAME_PADDING - HALF_FRAME_HEIGHT,
+				HALF_FRAME_WIDTH,
+				HALF_FRAME_HEIGHT,
+				HALF_FRAME_WIDTH,
+				HALF_FRAME_HEIGHT,
+				TEXTURE_WIDTH,
+				TEXTURE_HEIGHT
+		);
+
+		// left
+		context.drawTexture(
+				WINDOW_TEXTURE,
+				FRAME_PADDING,
+				FRAME_PADDING + HALF_FRAME_HEIGHT,
+				HALF_FRAME_WIDTH,
+				this.height - FRAME_PADDING * 2 - FRAME_HEIGHT,
+				0,
+				HALF_FRAME_HEIGHT - 1,
+				HALF_FRAME_WIDTH,
+				2,
+				TEXTURE_WIDTH,
+				TEXTURE_HEIGHT
+		);
+
+		// bottom
+		context.drawTexture(
+				WINDOW_TEXTURE,
+				FRAME_PADDING + HALF_FRAME_WIDTH,
+				this.height - FRAME_PADDING - HALF_FRAME_HEIGHT,
+				this.width - FRAME_PADDING * 2 - FRAME_WIDTH,
+				HALF_FRAME_HEIGHT,
+				HALF_FRAME_WIDTH - 1,
+				HALF_FRAME_HEIGHT,
+				2,
+				HALF_FRAME_HEIGHT,
+				TEXTURE_WIDTH,
+				TEXTURE_HEIGHT
+		);
+
+		// right
+		context.drawTexture(
+				WINDOW_TEXTURE,
+				this.width - FRAME_PADDING - HALF_FRAME_WIDTH,
+				FRAME_PADDING + HALF_FRAME_HEIGHT,
+				HALF_FRAME_WIDTH,
+				this.height - FRAME_PADDING * 2 - FRAME_HEIGHT,
+				HALF_FRAME_WIDTH,
+				HALF_FRAME_HEIGHT - 1,
+				HALF_FRAME_WIDTH,
+				2,
+				TEXTURE_WIDTH,
+				TEXTURE_HEIGHT
+		);
+
+		if (small) {
+			// top left
+			context.drawTexture(
+					WINDOW_TEXTURE,
+					FRAME_PADDING,
+					FRAME_PADDING + TABS_HEIGHT,
+					0,
+					0,
+					HALF_FRAME_WIDTH,
+					FRAME_CUT,
+					TEXTURE_WIDTH,
+					TEXTURE_HEIGHT
+			);
+			context.drawTexture(
+					WINDOW_TEXTURE,
+					FRAME_PADDING,
+					FRAME_PADDING + TABS_HEIGHT + FRAME_CUT,
+					0,
+					FRAME_CUT * 2 - FRAME_EXPAND,
+					HALF_FRAME_WIDTH,
+					HALF_FRAME_HEIGHT - TABS_HEIGHT - FRAME_CUT,
+					TEXTURE_WIDTH,
+					TEXTURE_HEIGHT
+			);
+
+			// top right
+			context.drawTexture(
+					WINDOW_TEXTURE,
+					this.width - FRAME_PADDING - HALF_FRAME_WIDTH,
+					FRAME_PADDING + TABS_HEIGHT,
+					HALF_FRAME_WIDTH,
+					0,
+					HALF_FRAME_WIDTH,
+					FRAME_CUT,
+					TEXTURE_WIDTH,
+					TEXTURE_HEIGHT
+			);
+			context.drawTexture(
+					WINDOW_TEXTURE,
+					this.width - FRAME_PADDING - HALF_FRAME_WIDTH,
+					FRAME_PADDING + TABS_HEIGHT + FRAME_CUT,
+					HALF_FRAME_WIDTH,
+					FRAME_CUT * 2 - FRAME_EXPAND,
+					HALF_FRAME_WIDTH,
+					HALF_FRAME_HEIGHT - TABS_HEIGHT - FRAME_CUT,
+					TEXTURE_WIDTH,
+					TEXTURE_HEIGHT
+			);
+
+			// top
+			context.drawTexture(
+					WINDOW_TEXTURE,
+					FRAME_PADDING + HALF_FRAME_WIDTH,
+					FRAME_PADDING + TABS_HEIGHT,
+					this.width - FRAME_PADDING * 2 - FRAME_WIDTH,
+					FRAME_CUT,
+					HALF_FRAME_WIDTH - 1,
+					0,
+					2,
+					FRAME_CUT,
+					TEXTURE_WIDTH,
+					TEXTURE_HEIGHT
+			);
+			context.drawTexture(
+					WINDOW_TEXTURE,
+					FRAME_PADDING + HALF_FRAME_WIDTH,
+					FRAME_PADDING + TABS_HEIGHT + FRAME_CUT,
+					this.width - FRAME_PADDING * 2 - FRAME_WIDTH,
+					HALF_FRAME_HEIGHT - FRAME_CUT,
+					HALF_FRAME_WIDTH - 1,
+					FRAME_CUT * 2 - FRAME_EXPAND,
+					2,
+					HALF_FRAME_HEIGHT - FRAME_CUT,
+					TEXTURE_WIDTH,
+					TEXTURE_HEIGHT
+			);
+		} else {
+			// top left
+			context.drawTexture(
+					WINDOW_TEXTURE,
+					FRAME_PADDING,
+					FRAME_PADDING + TABS_HEIGHT,
+					0,
+					0,
+					HALF_FRAME_WIDTH,
+					HALF_FRAME_HEIGHT - TABS_HEIGHT,
+					TEXTURE_WIDTH,
+					TEXTURE_HEIGHT
+			);
+
+			// top right
+			context.drawTexture(
+					WINDOW_TEXTURE,
+					this.width - FRAME_PADDING - HALF_FRAME_WIDTH,
+					FRAME_PADDING + TABS_HEIGHT,
+					HALF_FRAME_WIDTH,
+					0,
+					HALF_FRAME_WIDTH,
+					HALF_FRAME_HEIGHT - TABS_HEIGHT,
+					TEXTURE_WIDTH,
+					TEXTURE_HEIGHT
+			);
+
+			// top
+			context.drawTexture(
+					WINDOW_TEXTURE,
+					FRAME_PADDING + HALF_FRAME_WIDTH,
+					FRAME_PADDING + TABS_HEIGHT,
+					this.width - FRAME_PADDING * 2 - FRAME_WIDTH,
+					HALF_FRAME_HEIGHT,
+					HALF_FRAME_WIDTH - 1,
+					0,
+					2,
+					HALF_FRAME_HEIGHT,
+					TEXTURE_WIDTH,
+					TEXTURE_HEIGHT
+			);
+		}
+
+		var tmpText = SkillsMod.createTranslatable("text", "skills");
+		var tmpX = FRAME_PADDING + 8;
+		var tmpY = FRAME_PADDING + TABS_HEIGHT + 6;
+
+		context.drawText(
+				this.textRenderer,
+				tmpText,
+				tmpX,
+				tmpY,
+				0xff404040,
+				false
+		);
+
+		optActiveCategoryData.ifPresent(activeCategoryData ->
+				drawWindowWithCategory(context, mouseX, mouseY, activeCategoryData)
+		);
+	}
+
+	private void drawWindowWithCategory(DrawContext context, double mouseX, double mouseY, ExtendedClientCategoryData activeCategoryData) {
+		var mouse = getMousePos(mouseX, mouseY);
+		var activeCategory = activeCategoryData.getConfig();
+
+		var tmpX = this.width - FRAME_PADDING - 7;
+		var tmpY = FRAME_PADDING + TABS_HEIGHT + 6;
+
+		var startX = tmpX;
+
+		var tmpText = Text.literal(activeCategoryData.getPointsLeft()
+				+ (activeCategory.spentPointsLimit() == Integer.MAX_VALUE ? "" : "/" + activeCategoryData.getSpentPointsLeft())
+		);
+
+		tmpX -= this.textRenderer.getWidth(tmpText);
+		tmpX -= 1;
+
+		var pointsColor = activeCategory.colors().points();
+		var pointsStrokeColor = pointsColor.stroke().argb();
+		var pointsFillColor = pointsColor.fill().argb();
+		context.drawText(this.textRenderer, tmpText, tmpX - 1, tmpY, pointsStrokeColor, false);
+		context.drawText(this.textRenderer, tmpText, tmpX, tmpY - 1, pointsStrokeColor, false);
+		context.drawText(this.textRenderer, tmpText, tmpX + 1, tmpY, pointsStrokeColor, false);
+		context.drawText(this.textRenderer, tmpText, tmpX, tmpY + 1, pointsStrokeColor, false);
+		context.drawText(this.textRenderer, tmpText, tmpX, tmpY, pointsFillColor, false);
+		tmpX -= 1;
+
+		tmpText = SkillsMod.createTranslatable("text", "points_left");
+		tmpX -= this.textRenderer.getWidth(tmpText);
+		context.drawText(
+				this.textRenderer,
+				tmpText,
+				tmpX,
+				tmpY,
+				0xff404040,
+				false
+		);
+
+		if (isInsideArea(mouse, tmpX, tmpY, startX, tmpY + this.textRenderer.fontHeight)) {
+			var lines = new ArrayList<OrderedText>();
+			lines.add(SkillsMod.createTranslatable(
+					"tooltip",
+					"earned_points",
+					activeCategoryData.getEarnedPoints()
+			).asOrderedText());
+			lines.add(SkillsMod.createTranslatable(
+					"tooltip",
+					"spent_points",
+					activeCategoryData.getSpentPoints()
+							+ (activeCategory.spentPointsLimit() == Integer.MAX_VALUE ? "" : "/" + activeCategory.spentPointsLimit())
+			).asOrderedText());
+			setTooltip(lines);
+		}
+
+		if (activeCategoryData.hasExperience()) {
+			if (small) {
+				tmpX = this.width - FRAME_PADDING - 8 - 182;
+				tmpY = TABS_HEIGHT + 25;
+			} else {
+				tmpX = (this.width - 182) / 2;
+				tmpY = TABS_HEIGHT + 15;
+			}
+
+			context.drawTexture(ICONS_TEXTURE, tmpX, tmpY, 0, 64, 182, 5);
+			var width = Math.min(182, (int) (activeCategoryData.getExperienceProgress() * 183f));
+			if (width > 0) {
+				context.drawTexture(ICONS_TEXTURE, tmpX, tmpY, 0, 69, width, 5);
+			}
+
+			if (isInsideExperience(mouse, tmpX, tmpY)) {
+				var lines = new ArrayList<OrderedText>();
+				lines.add(SkillsMod.createTranslatable(
+						"tooltip",
+						"current_level",
+						activeCategoryData.getCurrentLevel()
+								+ (activeCategory.levelLimit() == Integer.MAX_VALUE ? "" : "/" + activeCategory.levelLimit())
+				).asOrderedText());
+				lines.add(SkillsMod.createTranslatable(
+						"tooltip",
+						"experience_progress",
+						activeCategoryData.getCurrentExperience(),
+						activeCategoryData.getRequiredExperience(),
+						MathHelper.floor(activeCategoryData.getExperienceProgress() * 100f)
+				).asOrderedText());
+				lines.add(SkillsMod.createTranslatable(
+						"tooltip",
+						"to_next_level",
+						activeCategoryData.getExperienceToNextLevel()
+				).asOrderedText());
+				setTooltip(lines);
+			}
+		}
+	}
+
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/network/packets/in/ExtendedShowCategoryInPacket.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/network/packets/in/ExtendedShowCategoryInPacket.java
@@ -1,0 +1,278 @@
+package net.bluelotuscoding.puffishskillleveling.client.network.packets.in;
+
+import net.minecraft.advancement.AdvancementFrame;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.registry.Registries;
+import net.puffish.skillsmod.api.Skill;
+import net.bluelotuscoding.puffishskillleveling.client.config.ExtendedClientBackgroundConfig;
+import net.bluelotuscoding.puffishskillleveling.client.config.ExtendedClientCategoryConfig;
+import net.puffish.skillsmod.client.config.ClientFrameConfig;
+import net.puffish.skillsmod.client.config.ClientIconConfig;
+import net.puffish.skillsmod.client.config.colors.ClientColorConfig;
+import net.puffish.skillsmod.client.config.colors.ClientColorsConfig;
+import net.puffish.skillsmod.client.config.colors.ClientConnectionsColorsConfig;
+import net.puffish.skillsmod.client.config.colors.ClientFillStrokeColorsConfig;
+import net.puffish.skillsmod.client.config.skill.ClientSkillConfig;
+import net.puffish.skillsmod.client.config.skill.ClientSkillConnectionConfig;
+import net.bluelotuscoding.puffishskillleveling.client.config.skill.ExtendedClientSkillDefinitionConfig;
+import net.bluelotuscoding.puffishskillleveling.client.data.ExtendedClientCategoryData;
+import net.puffish.skillsmod.common.BackgroundPosition;
+import net.puffish.skillsmod.common.FrameType;
+import net.puffish.skillsmod.common.IconType;
+import net.puffish.skillsmod.network.InPacket;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ExtendedShowCategoryInPacket implements InPacket {
+	private final ExtendedClientCategoryData category;
+
+	private ExtendedShowCategoryInPacket(ExtendedClientCategoryData category) {
+		this.category = category;
+	}
+
+	public static ExtendedShowCategoryInPacket read(PacketByteBuf buf) {
+		var category = readCategory(buf);
+
+		return new ExtendedShowCategoryInPacket(category);
+	}
+
+        public static ExtendedClientCategoryData readCategory(PacketByteBuf buf) {
+		var id = buf.readIdentifier();
+
+		var title = buf.readText();
+		var icon = readSkillIcon(buf);
+		var background = readBackground(buf);
+		var colors = readColors(buf);
+		var exclusiveRoot = buf.readBoolean();
+		var spentPointsLimit = buf.readInt();
+
+		var definitions = buf.readList(ExtendedShowCategoryInPacket::readDefinition)
+				.stream()
+				.collect(Collectors.toMap(ExtendedClientSkillDefinitionConfig::id, definition -> definition));
+
+		var skills = buf.readList(ExtendedShowCategoryInPacket::readSkill)
+				.stream()
+				.collect(Collectors.toMap(ClientSkillConfig::id, skill -> skill));
+
+		var normalConnections = buf.readList(ExtendedShowCategoryInPacket::readSkillConnection);
+		var exclusiveConnections = buf.readList(ExtendedShowCategoryInPacket::readSkillConnection);
+
+                var skillsInfo = buf.readMap(
+                                PacketByteBuf::readString,
+                                buf1 -> new SkillInfo(
+                                                buf1.readEnumConstant(Skill.State.class),
+                                                buf1.readInt()
+                                )
+                );
+
+                var skillsStates = skillsInfo.entrySet().stream()
+                                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().state()));
+                var skillLevels = skillsInfo.entrySet().stream()
+                                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().level()));
+
+                var spentPoints = buf.readInt();
+                var earnedPoints = buf.readInt();
+
+		var levelLimit = Integer.MAX_VALUE;
+		var currentLevel = Integer.MIN_VALUE;
+		var currentExperience = Integer.MIN_VALUE;
+		var requiredExperience = Integer.MIN_VALUE;
+		if (buf.readBoolean()) {
+			levelLimit = buf.readInt();
+			currentLevel = buf.readInt();
+			currentExperience = buf.readInt();
+			requiredExperience = buf.readInt();
+		}
+
+		var category = new ExtendedClientCategoryConfig(
+				id,
+				title,
+				icon,
+				background,
+				colors,
+				exclusiveRoot,
+				spentPointsLimit,
+				levelLimit,
+				definitions,
+				skills,
+				normalConnections,
+				exclusiveConnections
+		);
+
+                return new ExtendedClientCategoryData(
+                                category,
+                                skillsStates,
+                                skillLevels,
+                                spentPoints,
+                                earnedPoints,
+                                currentLevel,
+                                currentExperience,
+                                requiredExperience
+                );
+        }
+
+        private record SkillInfo(Skill.State state, int level) { }
+
+        public static ExtendedClientSkillDefinitionConfig readDefinition(PacketByteBuf buf) {
+                var id = buf.readString();
+                var type = buf.readIdentifier();
+                var maxLevels = buf.readInt();
+                var descriptions = buf.readList(PacketByteBuf::readText);
+                var extraDescriptions = buf.readList(PacketByteBuf::readText);
+                var title = buf.readText();
+                var frame = readFrameIcon(buf);
+                var icon = readSkillIcon(buf);
+                var size = buf.readFloat();
+                var mergeDescription = buf.readBoolean();
+
+                int cost = 1;
+                int requiredSkills = 1;
+                int requiredPoints = 0;
+                int requiredSpentPoints = 0;
+                int requiredExclusions = 1;
+                boolean hasLevelRewards = false;
+
+                if (buf.readableBytes() >= 4) {
+                        cost = buf.readInt();
+                        if (buf.readableBytes() >= 4) {
+                                requiredSkills = buf.readInt();
+                                if (buf.readableBytes() >= 4) {
+                                        requiredPoints = buf.readInt();
+                                        if (buf.readableBytes() >= 4) {
+                                                requiredSpentPoints = buf.readInt();
+                                                if (buf.readableBytes() >= 4) {
+                                                        requiredExclusions = buf.readInt();
+                                                        if (buf.readableBytes() >= 1) {
+                                                                hasLevelRewards = buf.readBoolean();
+                                                        }
+                                                }
+                                        }
+                                }
+                        }
+                }
+
+                return new ExtendedClientSkillDefinitionConfig(
+                        id,
+                        type,
+                        maxLevels,
+                        descriptions,
+                        extraDescriptions,
+                        title,
+                        icon,
+                        frame,
+                        size,
+                        mergeDescription,
+                        cost,
+
+                                requiredSkills,
+                                requiredPoints,
+                                requiredSpentPoints,
+                                requiredExclusions,
+                                hasLevelRewards
+                );
+        }
+
+	public static ClientIconConfig readSkillIcon(PacketByteBuf buf) {
+		var type = buf.readEnumConstant(IconType.class);
+		return switch (type) {
+			case EFFECT -> {
+				var effect = buf.readIdentifier();
+				yield new ClientIconConfig.EffectIconConfig(Registries.STATUS_EFFECT.get(effect));
+			}
+			case ITEM -> {
+				var itemStack = buf.readItemStack();
+				yield new ClientIconConfig.ItemIconConfig(itemStack);
+			}
+			case TEXTURE -> {
+				var texture = buf.readIdentifier();
+				yield new ClientIconConfig.TextureIconConfig(texture);
+			}
+		};
+	}
+
+	public static ClientFrameConfig readFrameIcon(PacketByteBuf buf) {
+		var type = buf.readEnumConstant(FrameType.class);
+		return switch (type) {
+			case ADVANCEMENT -> {
+				var advancementFrame = buf.readEnumConstant(AdvancementFrame.class);
+				yield new ClientFrameConfig.AdvancementFrameConfig(advancementFrame);
+			}
+			case TEXTURE -> {
+				var lockedTexture = buf.readOptional(PacketByteBuf::readIdentifier);
+				var availableTexture = buf.readIdentifier();
+				var affordableTexture = buf.readOptional(PacketByteBuf::readIdentifier);
+				var unlockedTexture = buf.readIdentifier();
+				var excludedTexture = buf.readOptional(PacketByteBuf::readIdentifier);
+				yield new ClientFrameConfig.TextureFrameConfig(
+						lockedTexture,
+						availableTexture,
+						affordableTexture,
+						unlockedTexture,
+						excludedTexture
+				);
+			}
+		};
+	}
+
+	public static ExtendedClientBackgroundConfig readBackground(PacketByteBuf buf) {
+		var texture = buf.readIdentifier();
+		var width = buf.readInt();
+		var height = buf.readInt();
+		var position = buf.readEnumConstant(BackgroundPosition.class);
+
+		return ExtendedClientBackgroundConfig.create(texture, width, height, position);
+	}
+
+	public static ClientColorsConfig readColors(PacketByteBuf buf) {
+		var connections = readConnectionsColors(buf);
+		var points = readFillStrokeColors(buf);
+
+		return new ClientColorsConfig(connections, points);
+	}
+
+	public static ClientConnectionsColorsConfig readConnectionsColors(PacketByteBuf buf) {
+		var locked = readFillStrokeColors(buf);
+		var available = readFillStrokeColors(buf);
+		var affordable = readFillStrokeColors(buf);
+		var unlocked = readFillStrokeColors(buf);
+		var excluded = readFillStrokeColors(buf);
+
+		return new ClientConnectionsColorsConfig(locked, available, affordable, unlocked, excluded);
+	}
+
+	public static ClientFillStrokeColorsConfig readFillStrokeColors(PacketByteBuf buf) {
+		var fill = readColor(buf);
+		var stroke = readColor(buf);
+
+		return new ClientFillStrokeColorsConfig(fill, stroke);
+	}
+
+	public static ClientColorConfig readColor(PacketByteBuf buf) {
+		var argb = buf.readInt();
+
+		return new ClientColorConfig(argb);
+	}
+
+	public static ClientSkillConfig readSkill(PacketByteBuf buf) {
+		var id = buf.readString();
+		var x = buf.readInt();
+		var y = buf.readInt();
+		var definition = buf.readString();
+		var isRoot = buf.readBoolean();
+
+		return new ClientSkillConfig(id, x, y, definition, isRoot);
+	}
+
+	public static ClientSkillConnectionConfig readSkillConnection(PacketByteBuf buf) {
+		var skillAId = buf.readString();
+		var skillBId = buf.readString();
+		var bidirectional = buf.readBoolean();
+
+		return new ClientSkillConnectionConfig(skillAId, skillBId, bidirectional);
+	}
+
+	public ExtendedClientCategoryData getCategory() {
+		return category;
+	}
+}

--- a/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/network/packets/in/ExtendedSkillUpdateInPacket.java
+++ b/Common/src/main/java/net/bluelotuscoding/puffishskillleveling/client/network/packets/in/ExtendedSkillUpdateInPacket.java
@@ -1,0 +1,51 @@
+package net.bluelotuscoding.puffishskillleveling.client.network.packets.in;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.network.InPacket;
+
+public class ExtendedSkillUpdateInPacket implements InPacket {
+	private final Identifier categoryId;
+	private final String skillId;
+        private final boolean unlocked;
+        private final int level;
+
+        private ExtendedSkillUpdateInPacket(Identifier categoryId, String skillId, boolean unlocked, int level) {
+                this.categoryId = categoryId;
+                this.skillId = skillId;
+                this.unlocked = unlocked;
+                this.level = level;
+        }
+
+        public static ExtendedSkillUpdateInPacket read(PacketByteBuf buf) {
+                var categoryId = buf.readIdentifier();
+                var skillId = buf.readString();
+                var unlocked = buf.readBoolean();
+                int level = unlocked ? 1 : 0;
+                if (buf.readableBytes() >= 4) {
+                        level = buf.readInt();
+                }
+                return new ExtendedSkillUpdateInPacket(
+                                categoryId,
+                                skillId,
+                                unlocked,
+                                level
+                );
+        }
+
+	public Identifier getCategoryId() {
+		return categoryId;
+	}
+
+	public String getSkillId() {
+		return skillId;
+	}
+
+        public boolean isUnlocked() {
+                return unlocked;
+        }
+
+        public int getLevel() {
+                return level;
+        }
+}


### PR DESCRIPTION
## Summary
- Provide ExtendedSkillsClientMod with support for new packet wrappers and UI screen
- Include ExtendedClient* data/config classes and extended SkillsScreen
- Add ExtendedShowCategoryInPacket and ExtendedSkillUpdateInPacket that read optional fields safely

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_689858d4bcd08327824c39cf762a2663