### PR TITLE
Add extensible skill API and operations

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/ExtendedSkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/ExtendedSkillsMod.java
@@ -1,0 +1,61 @@
+package net.puffish.skillsmod;
+
+import net.minecraft.server.MinecraftServer;
+import net.puffish.skillsmod.calculation.operation.ExtendedBuiltinOperations;
+import net.puffish.skillsmod.network.Packets;
+import net.puffish.skillsmod.server.event.ServerEventReceiver;
+import net.puffish.skillsmod.server.network.ServerPacketSender;
+import net.puffish.skillsmod.server.setup.ServerPlatform;
+import net.puffish.skillsmod.server.setup.ServerRegistrar;
+
+import java.nio.file.Path;
+
+/**
+ * Extension of the base {@link SkillsMod} that wires in the additional
+ * functionality required by this project.  Custom configuration handling and
+ * network packet registration are exposed through overridable hooks so the
+ * upstream mod can remain untouched.
+ */
+public class ExtendedSkillsMod extends SkillsMod {
+
+    protected ExtendedSkillsMod(Path modConfigDir, ServerPacketSender packetSender, ServerPlatform platform) {
+        super(modConfigDir, packetSender, platform);
+    }
+
+    /**
+     * Bootstraps the mod using this extended implementation.
+     */
+    public static void setup(
+            Path configDir,
+            ServerRegistrar registrar,
+            ServerEventReceiver eventReceiver,
+            ServerPacketSender packetSender,
+            ServerPlatform platform
+    ) {
+        SkillsMod.setup(configDir, registrar, eventReceiver, packetSender, platform, ExtendedSkillsMod::new);
+    }
+
+    @Override
+    protected void registerPackets(ServerRegistrar registrar) {
+        super.registerPackets(registrar);
+        registrar.registerOutPacket(Packets.NEW_POINT);
+    }
+
+    @Override
+    protected void registerBuiltinOperations() {
+        ExtendedBuiltinOperations.register();
+    }
+
+    @Override
+    protected void copyConfigFromJar() {
+        super.copyConfigFromJar();
+        // Additional configuration files could be copied here if required
+    }
+
+    @Override
+    protected void loadModConfig(MinecraftServer server) {
+        super.loadModConfig(server);
+        // Custom configuration parsing can be added here in the future
+    }
+}
+

--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -95,7 +95,7 @@ public class SkillsMod {
 			c -> (categoryId, skillId) -> c.forEach(e -> e.onSkillLock(categoryId, skillId))
 	);
 
-	private static SkillsMod instance;
+        protected static SkillsMod instance;
 
 	private final PrefixedLogger logger = new PrefixedLogger(SkillsAPI.MOD_ID);
 
@@ -108,7 +108,7 @@ public class SkillsMod {
 			() -> { }
 	);
 
-	private SkillsMod(Path modConfigDir, ServerPacketSender packetSender, ServerPlatform platform) {
+        protected SkillsMod(Path modConfigDir, ServerPacketSender packetSender, ServerPlatform platform) {
 		this.modConfigDir = modConfigDir;
 		this.packetSender = packetSender;
 		this.platform = platform;
@@ -118,48 +118,51 @@ public class SkillsMod {
 		return instance;
 	}
 
-	public static void setup(
-			Path configDir,
-			ServerRegistrar registrar,
-			ServerEventReceiver eventReceiver,
-			ServerPacketSender packetSender,
-			ServerPlatform platform
-	) {
-		var modConfigDir = configDir.resolve(SkillsAPI.MOD_ID);
-		try {
-			Files.createDirectories(modConfigDir);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
+        public static void setup(
+                        Path configDir,
+                        ServerRegistrar registrar,
+                        ServerEventReceiver eventReceiver,
+                        ServerPacketSender packetSender,
+                        ServerPlatform platform
+        ) {
+                setup(configDir, registrar, eventReceiver, packetSender, platform, SkillsMod::new);
+        }
 
-		instance = new SkillsMod(modConfigDir, packetSender, platform);
+        @FunctionalInterface
+        protected interface InstanceFactory {
+                SkillsMod create(Path modConfigDir, ServerPacketSender packetSender, ServerPlatform platform);
+        }
 
-		registrar.registerInPacket(
-				Packets.SKILL_CLICK,
-				SkillClickInPacket::read,
-				instance::onSkillClickPacket
-		);
+        protected static void setup(
+                        Path configDir,
+                        ServerRegistrar registrar,
+                        ServerEventReceiver eventReceiver,
+                        ServerPacketSender packetSender,
+                        ServerPlatform platform,
+                        InstanceFactory factory
+        ) {
+                var modConfigDir = configDir.resolve(SkillsAPI.MOD_ID);
+                try {
+                        Files.createDirectories(modConfigDir);
+                } catch (IOException e) {
+                        throw new RuntimeException(e);
+                }
 
-		registrar.registerOutPacket(Packets.SHOW_CATEGORY);
-		registrar.registerOutPacket(Packets.HIDE_CATEGORY);
-		registrar.registerOutPacket(Packets.SKILL_UPDATE);
-		registrar.registerOutPacket(Packets.POINTS_UPDATE);
-		registrar.registerOutPacket(Packets.EXPERIENCE_UPDATE);
-		registrar.registerOutPacket(Packets.SHOW_TOAST);
-		registrar.registerOutPacket(Packets.OPEN_SCREEN);
-		registrar.registerOutPacket(Packets.NEW_POINT);
+                instance = factory.create(modConfigDir, packetSender, platform);
 
-		eventReceiver.registerListener(instance.new EventListener());
+                instance.registerPackets(registrar);
 
-		SkillsGameRules.register(registrar);
-		SkillsArgumentTypes.register(registrar);
+                eventReceiver.registerListener(instance.new EventListener());
 
-		BuiltinRewards.register();
-		BuiltinOperations.register();
-		BuiltinExperienceSources.register();
+                SkillsGameRules.register(registrar);
+                SkillsArgumentTypes.register(registrar);
 
-		LegacyBuiltinPrototypes.register();
-	}
+                BuiltinRewards.register();
+                instance.registerBuiltinOperations();
+                BuiltinExperienceSources.register();
+
+                LegacyBuiltinPrototypes.register();
+        }
 
 	public static Identifier createIdentifier(String path) {
 		return new Identifier(SkillsAPI.MOD_ID, path);
@@ -176,18 +179,38 @@ public class SkillsMod {
 		return Text.translatable(Util.createTranslationKey(type, createIdentifier(path)), args);
 	}
 
-	public PrefixedLogger getLogger() {
-		return logger;
-	}
+        public PrefixedLogger getLogger() {
+                return logger;
+        }
 
-	private void copyConfigFromJar() {
-		PathUtils.copyFileFromJar(
-				Path.of("config", "config.json"),
-				modConfigDir.resolve("config.json")
-		);
-	}
+        protected void registerPackets(ServerRegistrar registrar) {
+                registrar.registerInPacket(
+                                Packets.SKILL_CLICK,
+                                SkillClickInPacket::read,
+                                this::onSkillClickPacket
+                );
 
-	private void loadModConfig(MinecraftServer server) {
+                registrar.registerOutPacket(Packets.SHOW_CATEGORY);
+                registrar.registerOutPacket(Packets.HIDE_CATEGORY);
+                registrar.registerOutPacket(Packets.SKILL_UPDATE);
+                registrar.registerOutPacket(Packets.POINTS_UPDATE);
+                registrar.registerOutPacket(Packets.EXPERIENCE_UPDATE);
+                registrar.registerOutPacket(Packets.SHOW_TOAST);
+                registrar.registerOutPacket(Packets.OPEN_SCREEN);
+        }
+
+        protected void registerBuiltinOperations() {
+                BuiltinOperations.register();
+        }
+
+        protected void copyConfigFromJar() {
+                PathUtils.copyFileFromJar(
+                                Path.of("config", "config.json"),
+                                modConfigDir.resolve("config.json")
+                );
+        }
+
+        protected void loadModConfig(MinecraftServer server) {
 		if (!Files.exists(modConfigDir) || PathUtils.isDirectoryEmpty(modConfigDir)) {
 			copyConfigFromJar();
 		}

--- a/Common/src/main/java/net/puffish/skillsmod/api/ExtendedCategory.java
+++ b/Common/src/main/java/net/puffish/skillsmod/api/ExtendedCategory.java
@@ -1,0 +1,53 @@
+package net.puffish.skillsmod.api;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+import java.util.stream.Stream;
+
+/**
+ * Extension of the public {@link Category} API that exposes point management
+ * and reset operations used internally by the addon.  These methods mirror the
+ * capabilities of {@link net.puffish.skillsmod.impl.CategoryImpl} while keeping
+ * the upstream API untouched.
+ */
+public interface ExtendedCategory extends Category {
+
+    Stream<Identifier> streamPointsSources(ServerPlayerEntity player);
+
+    int getPoints(ServerPlayerEntity player, Identifier source);
+
+    void setPoints(ServerPlayerEntity player, Identifier source, int count);
+
+    void addPoints(ServerPlayerEntity player, Identifier source, int count);
+
+    void setPointsSilently(ServerPlayerEntity player, Identifier source, int count);
+
+    void addPointsSilently(ServerPlayerEntity player, Identifier source, int count);
+
+    void resetSkills(ServerPlayerEntity player);
+
+    void unlock(ServerPlayerEntity player);
+
+    void lock(ServerPlayerEntity player);
+
+    boolean isUnlocked(ServerPlayerEntity player);
+
+    void erase(ServerPlayerEntity player);
+
+    int getSpentPoints(ServerPlayerEntity player);
+
+    int getPointsTotal(ServerPlayerEntity player);
+
+    int getPointsLeft(ServerPlayerEntity player);
+
+    @Deprecated
+    int getExtraPoints(ServerPlayerEntity player);
+
+    @Deprecated
+    void setExtraPoints(ServerPlayerEntity player, int count);
+
+    @Deprecated
+    void addExtraPoints(ServerPlayerEntity player, int count);
+}
+

--- a/Common/src/main/java/net/puffish/skillsmod/api/ExtendedSkillsAPI.java
+++ b/Common/src/main/java/net/puffish/skillsmod/api/ExtendedSkillsAPI.java
@@ -1,0 +1,38 @@
+package net.puffish.skillsmod.api;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.experience.source.ExperienceSource;
+import net.puffish.skillsmod.config.skill.SkillRewardConfig;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Additional helper methods built on top of {@link SkillsAPI}.  These simplify
+ * updating rewards and experience sources without exposing internal classes to
+ * consumers of the base API.
+ */
+public final class ExtendedSkillsAPI {
+
+    private ExtendedSkillsAPI() {
+    }
+
+    public static void updateRewards(ServerPlayerEntity player, Predicate<SkillRewardConfig> predicate) {
+        SkillsMod.getInstance().updateRewards(player, predicate);
+    }
+
+    public static void updateExperienceSources(
+            ServerPlayerEntity player,
+            Predicate<ExperienceSource> predicate,
+            Function<ExperienceSource, Integer> function
+    ) {
+        SkillsMod.getInstance().visitExperienceSources(player, source -> {
+            if (predicate.test(source)) {
+                return function.apply(source);
+            }
+            return 0;
+        });
+    }
+}
+

--- a/Common/src/main/java/net/puffish/skillsmod/calculation/operation/ExtendedBuiltinOperations.java
+++ b/Common/src/main/java/net/puffish/skillsmod/calculation/operation/ExtendedBuiltinOperations.java
@@ -1,0 +1,19 @@
+package net.puffish.skillsmod.calculation.operation;
+
+import net.puffish.skillsmod.calculation.operation.builtin.ItemStackNbtCondition;
+
+/**
+ * Registers the default operations supplied by the base mod and adds the
+ * additional operations required by this project.
+ */
+public final class ExtendedBuiltinOperations extends BuiltinOperations {
+
+    private ExtendedBuiltinOperations() {
+    }
+
+    public static void register() {
+        BuiltinOperations.register();
+        ItemStackNbtCondition.register();
+    }
+}
+

--- a/Common/src/main/java/net/puffish/skillsmod/calculation/operation/builtin/ItemStackNbtCondition.java
+++ b/Common/src/main/java/net/puffish/skillsmod/calculation/operation/builtin/ItemStackNbtCondition.java
@@ -1,0 +1,67 @@
+package net.puffish.skillsmod.calculation.operation.builtin;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.predicate.NbtPredicate;
+import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.api.calculation.operation.Operation;
+import net.puffish.skillsmod.api.calculation.operation.OperationConfigContext;
+import net.puffish.skillsmod.api.calculation.prototype.BuiltinPrototypes;
+import net.puffish.skillsmod.api.json.BuiltinJson;
+import net.puffish.skillsmod.api.json.JsonElement;
+import net.puffish.skillsmod.api.json.JsonObject;
+import net.puffish.skillsmod.api.util.Problem;
+import net.puffish.skillsmod.api.util.Result;
+import net.puffish.skillsmod.util.LegacyUtils;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+/**
+ * Operation that tests an {@link ItemStack} against an {@link NbtPredicate}.
+ */
+public final class ItemStackNbtCondition implements Operation<ItemStack, Boolean> {
+    private final NbtPredicate nbt;
+
+    private ItemStackNbtCondition(NbtPredicate nbt) {
+        this.nbt = nbt;
+    }
+
+    public static void register() {
+        BuiltinPrototypes.ITEM_STACK.registerOperation(
+                SkillsMod.createIdentifier("test_nbt"),
+                BuiltinPrototypes.BOOLEAN,
+                ItemStackNbtCondition::parse
+        );
+    }
+
+    public static Result<ItemStackNbtCondition, Problem> parse(OperationConfigContext context) {
+        return context.getData()
+                .andThen(JsonElement::getAsObject)
+                .andThen(LegacyUtils.wrapNoUnused(ItemStackNbtCondition::parse, context));
+    }
+
+    public static Result<ItemStackNbtCondition, Problem> parse(JsonObject rootObject) {
+        var problems = new ArrayList<Problem>();
+
+        var optNbt = rootObject.get("nbt")
+                .andThen(BuiltinJson::parseNbtPredicate)
+                .ifFailure(problems::add)
+                .getSuccess();
+
+        if (optNbt.isEmpty()) {
+            problems.add(rootObject.getPath().createProblem("Missing 'nbt' property."));
+        }
+
+        if (problems.isEmpty()) {
+            return Result.success(new ItemStackNbtCondition(optNbt.orElseThrow()));
+        } else {
+            return Result.failure(Problem.combine(problems));
+        }
+    }
+
+    @Override
+    public Optional<Boolean> apply(ItemStack itemStack) {
+        return Optional.of(nbt.test(itemStack));
+    }
+}
+

--- a/Common/src/main/java/net/puffish/skillsmod/impl/CategoryImpl.java
+++ b/Common/src/main/java/net/puffish/skillsmod/impl/CategoryImpl.java
@@ -3,7 +3,7 @@ package net.puffish.skillsmod.impl;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.puffish.skillsmod.SkillsMod;
-import net.puffish.skillsmod.api.Category;
+import net.puffish.skillsmod.api.ExtendedCategory;
 import net.puffish.skillsmod.api.Experience;
 import net.puffish.skillsmod.api.Skill;
 import net.puffish.skillsmod.util.PointSources;
@@ -11,7 +11,7 @@ import net.puffish.skillsmod.util.PointSources;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public class CategoryImpl implements Category {
+public class CategoryImpl implements ExtendedCategory {
 	private final Identifier categoryId;
 
 	public CategoryImpl(Identifier categoryId) {

--- a/Fabric/src/main/java/net/puffish/skillsmod/main/FabricMain.java
+++ b/Fabric/src/main/java/net/puffish/skillsmod/main/FabricMain.java
@@ -16,7 +16,7 @@ import net.minecraft.registry.Registry;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.GameRules;
-import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.ExtendedSkillsMod;
 import net.puffish.skillsmod.mixin.GameRulesAccessor;
 import net.puffish.skillsmod.network.InPacket;
 import net.puffish.skillsmod.network.OutPacket;
@@ -33,7 +33,7 @@ public class FabricMain implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		SkillsMod.setup(
+                ExtendedSkillsMod.setup(
 				FabricLoader.getInstance().getConfigDir(),
 				new ServerRegistrarImpl(),
 				new ServerEventReceiverImpl(),

--- a/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
+++ b/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
@@ -26,7 +26,7 @@ import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.server.ServerLifecycleHooks;
-import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.ExtendedSkillsMod;
 import net.puffish.skillsmod.api.SkillsAPI;
 import net.puffish.skillsmod.mixin.GameRulesAccessor;
 import net.puffish.skillsmod.network.InPacket;
@@ -56,7 +56,7 @@ public class ForgeMain {
 		forgeEventBus.addListener(this::onOnDatapackSyncEvent);
 		forgeEventBus.addListener(this::onRegisterCommands);
 
-		SkillsMod.setup(
+                ExtendedSkillsMod.setup(
 				FMLPaths.CONFIGDIR.get(),
 				new ServerRegistrarImpl(),
 				new ServerEventReceiverImpl(),


### PR DESCRIPTION
## Summary
- add `ExtendedSkillsMod` with overridable config and packet hooks
- expose point management via `ExtendedCategory` and helper utilities
- register new `ItemStackNbtCondition` through `ExtendedBuiltinOperations`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689858d605dc83278e830a74b168e03a