### PR TITLE
Rename per-level reward for addon and init registration

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -38,7 +38,7 @@ import net.puffish.skillsmod.impl.config.ConfigContextImpl;
 import net.puffish.skillsmod.impl.rewards.RewardUpdateContextImpl;
 import net.puffish.skillsmod.network.Packets;
 import net.puffish.skillsmod.reward.BuiltinRewards;
-import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
+import net.puffish.skillsmod.reward.builtin.AddonPerLevelReward;
 import net.puffish.skillsmod.reward.builtin.PointsReward;
 import net.puffish.skillsmod.server.data.CategoryData;
 import net.puffish.skillsmod.server.data.PlayerData;
@@ -764,7 +764,7 @@ public class SkillsMod {
             if (levelChange != 0) {
                 for (var reward : definition.rewards()) {
                     var inst = reward.instance();
-                    if (inst instanceof PerLevelRewardsReward plr) {
+                    if (inst instanceof AddonPerLevelReward plr) {
                         if (plr.getSkillId() == null || plr.getSkillId().equals(skill.id())) {
                             int newLevel = Math.min(count, plr.getMaxLevel());
                             int oldLevel = Math.min(prev, plr.getMaxLevel());

--- a/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
+++ b/Common/src/main/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfig.java
@@ -15,7 +15,7 @@ import net.puffish.skillsmod.util.LegacyUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
+import net.puffish.skillsmod.reward.builtin.AddonPerLevelReward;
 
 public record SkillDefinitionConfig(
 
@@ -175,10 +175,10 @@ public record SkillDefinitionConfig(
 
                int rewardMaxLevel = rewards.stream()
                                .map(SkillRewardConfig::instance)
-                               .filter(PerLevelRewardsReward.class::isInstance)
-                               .map(PerLevelRewardsReward.class::cast)
+                               .filter(AddonPerLevelReward.class::isInstance)
+                               .map(AddonPerLevelReward.class::cast)
                                .filter(reward -> reward.getSkillId() == null || reward.getSkillId().equals(id))
-                               .mapToInt(PerLevelRewardsReward::getMaxLevel)
+                               .mapToInt(AddonPerLevelReward::getMaxLevel)
                                .max()
                                .orElse(1);
 

--- a/Common/src/main/java/net/puffish/skillsmod/reward/BuiltinRewards.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/BuiltinRewards.java
@@ -5,7 +5,6 @@ import net.puffish.skillsmod.reward.builtin.CommandReward;
 import net.puffish.skillsmod.reward.builtin.PointsReward;
 import net.puffish.skillsmod.reward.builtin.ScoreboardReward;
 import net.puffish.skillsmod.reward.builtin.TagReward;
-import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
 
 public class BuiltinRewards {
 	public static void register() {
@@ -13,7 +12,6 @@ public class BuiltinRewards {
 		CommandReward.register();
 		PointsReward.register();
 		ScoreboardReward.register();
-		TagReward.register();
-		PerLevelRewardsReward.register();
-	}
+                TagReward.register();
+        }
 }

--- a/Common/src/main/java/net/puffish/skillsmod/reward/builtin/AddonPerLevelReward.java
+++ b/Common/src/main/java/net/puffish/skillsmod/reward/builtin/AddonPerLevelReward.java
@@ -24,8 +24,21 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-public class PerLevelRewardsReward implements Reward {
-	public static final Identifier ID = SkillsMod.createIdentifier("per_level_rewards");
+/**
+ * Reward that grants a list of nested rewards for each level of a target skill.
+ *
+ * <p>Configuration:</p>
+ * <ul>
+ *   <li><code>skill_id</code> – skill to track.</li>
+ *   <li><code>levels</code> – map of level numbers to reward arrays.</li>
+ *   <li><code>max_skill_level</code> – optional maximum level, defaults to the
+ *       highest key in {@code levels}.</li>
+ *   <li><code>points_per_level</code> – optional points cost per level,
+ *       defaults to {@code 0}.</li>
+ * </ul>
+ */
+public class AddonPerLevelReward implements Reward {
+        public static final Identifier ID = SkillsMod.createIdentifier("per_level_rewards");
 
     private final Map<Integer, List<SkillRewardConfig>> levelRewards;
     private final String skillId;
@@ -33,7 +46,7 @@ public class PerLevelRewardsReward implements Reward {
     private final int pointsPerLevel;
     private final Map<UUID, Integer> counts = new HashMap<>();
 
-    private PerLevelRewardsReward(Map<Integer, List<SkillRewardConfig>> levelRewards, String skillId, int maxLevel, int pointsPerLevel) {
+    private AddonPerLevelReward(Map<Integer, List<SkillRewardConfig>> levelRewards, String skillId, int maxLevel, int pointsPerLevel) {
         this.levelRewards = levelRewards;
         this.skillId = skillId;
         this.maxLevel = maxLevel;
@@ -52,17 +65,17 @@ public class PerLevelRewardsReward implements Reward {
         return pointsPerLevel;
     }
 
-	public static void register() {
-	SkillsAPI.registerReward(ID, PerLevelRewardsReward::parse);
-	}
+        public static void register() {
+        SkillsAPI.registerReward(ID, AddonPerLevelReward::parse);
+        }
 
-        static Result<PerLevelRewardsReward, Problem> parse(RewardConfigContext context) {
-	return context.getData()
-		.andThen(JsonElement::getAsObject)
-		.andThen(LegacyUtils.wrapNoUnused(obj -> parse(obj, context), context));
-	}
+        static Result<AddonPerLevelReward, Problem> parse(RewardConfigContext context) {
+        return context.getData()
+                .andThen(JsonElement::getAsObject)
+                .andThen(LegacyUtils.wrapNoUnused(obj -> parse(obj, context), context));
+        }
 
-        static Result<PerLevelRewardsReward, Problem> parse(JsonObject rootObject, ConfigContext context) {
+        static Result<AddonPerLevelReward, Problem> parse(JsonObject rootObject, ConfigContext context) {
         var problems = new ArrayList<Problem>();
 
         var optLevelsMap = rootObject.getObject("levels")
@@ -119,7 +132,7 @@ public class PerLevelRewardsReward implements Reward {
         int optPointsPerLevel = optPointsPerLevelTmp.orElse(0);
 
         if (problems.isEmpty()) {
-            return Result.success(new PerLevelRewardsReward(levelRewards,
+            return Result.success(new AddonPerLevelReward(levelRewards,
                             optSkillId.orElse(null),
                             optMaxLevelTmp.orElse(Math.max(1, definedMaxLevel)),
                             optPointsPerLevel));

--- a/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/data/CategoryData.java
@@ -11,7 +11,7 @@ import net.puffish.skillsmod.config.CategoryConfig;
 import net.puffish.skillsmod.config.GeneralConfig;
 import net.puffish.skillsmod.config.skill.SkillConfig;
 import net.puffish.skillsmod.config.skill.SkillDefinitionConfig;
-import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
+import net.puffish.skillsmod.reward.builtin.AddonPerLevelReward;
 import net.puffish.skillsmod.util.PointSources;
 
 import java.util.HashMap;
@@ -104,7 +104,7 @@ public class CategoryData {
 
                for (var reward : definition.rewards()) {
                        var inst = reward.instance();
-                       if (inst instanceof PerLevelRewardsReward plr) {
+                       if (inst instanceof AddonPerLevelReward plr) {
                                if (plr.getSkillId() == null || plr.getSkillId().equals(skill.id())) {
                                        maxLevels = Math.max(maxLevels, plr.getMaxLevel());
                                }
@@ -151,7 +151,7 @@ public class CategoryData {
                 int cost = definition.cost();
                 for (var reward : definition.rewards()) {
                         var inst = reward.instance();
-                        if (inst instanceof PerLevelRewardsReward plr) {
+                        if (inst instanceof AddonPerLevelReward plr) {
                                 if (plr.getSkillId() == null || plr.getSkillId().equals(skill.id())) {
                                         cost = Math.max(cost, plr.getPointsPerLevel());
                                 }

--- a/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ShowCategoryOutPacket.java
+++ b/Common/src/main/java/net/puffish/skillsmod/server/network/packets/out/ShowCategoryOutPacket.java
@@ -22,7 +22,7 @@ import net.puffish.skillsmod.config.skill.SkillDefinitionsConfig;
 import net.puffish.skillsmod.config.skill.SkillsConfig;
 import net.puffish.skillsmod.network.OutPacket;
 import net.puffish.skillsmod.network.Packets;
-import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
+import net.puffish.skillsmod.reward.builtin.AddonPerLevelReward;
 import net.puffish.skillsmod.server.data.CategoryData;
 
 public record ShowCategoryOutPacket(CategoryConfig category, CategoryData categoryData) implements OutPacket {
@@ -90,7 +90,7 @@ public record ShowCategoryOutPacket(CategoryConfig category, CategoryData catego
 		buf.writeInt(definition.requiredPoints());
 		buf.writeInt(definition.requiredSpentPoints());
                 buf.writeInt(definition.requiredExclusions());
-                buf.writeBoolean(definition.rewards().stream().anyMatch(reward -> reward.type().equals(PerLevelRewardsReward.ID)));
+                buf.writeBoolean(definition.rewards().stream().anyMatch(reward -> reward.type().equals(AddonPerLevelReward.ID)));
 	}
 
 	public void write(PacketByteBuf buf, SkillsConfig skills) {

--- a/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/config/skill/SkillDefinitionConfigTest.java
@@ -4,7 +4,7 @@ import net.minecraft.server.MinecraftServer;
 import net.puffish.skillsmod.api.config.ConfigContext;
 import net.puffish.skillsmod.api.json.JsonElement;
 import net.puffish.skillsmod.api.json.JsonPath;
-import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
+import net.puffish.skillsmod.reward.builtin.AddonPerLevelReward;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +23,7 @@ public class SkillDefinitionConfigTest {
 
     static {
         try {
-            PerLevelRewardsReward.register();
+            AddonPerLevelReward.register();
         } catch (IllegalStateException ignored) {
         }
     }

--- a/Common/src/test/java/net/puffish/skillsmod/reward/builtin/AddonPerLevelRewardTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/reward/builtin/AddonPerLevelRewardTest.java
@@ -9,7 +9,7 @@ import net.puffish.skillsmod.api.util.Result;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class PerLevelRewardsRewardTest {
+public class AddonPerLevelRewardTest {
 
 	private static class DummyContext implements RewardConfigContext {
 	    private final JsonElement data;
@@ -34,11 +34,11 @@ public class PerLevelRewardsRewardTest {
 	    }
 	}
 
-	private static Result<PerLevelRewardsReward, Problem> parse(String json) {
-	    var element = JsonElement.parseString(json, JsonPath.create("test"))
-	            .getSuccess().orElseThrow();
-	    return PerLevelRewardsReward.parse(new DummyContext(element));
-	}
+        private static Result<AddonPerLevelReward, Problem> parse(String json) {
+            var element = JsonElement.parseString(json, JsonPath.create("test"))
+                    .getSuccess().orElseThrow();
+            return AddonPerLevelReward.parse(new DummyContext(element));
+        }
 
         @Test
         public void testValidValues() {

--- a/Common/src/test/java/net/puffish/skillsmod/server/data/CategoryDataTest.java
+++ b/Common/src/test/java/net/puffish/skillsmod/server/data/CategoryDataTest.java
@@ -18,7 +18,7 @@ import net.puffish.skillsmod.config.skill.SkillRewardConfig;
 import net.puffish.skillsmod.config.skill.SkillConnectionsConfig;
 import net.puffish.skillsmod.config.skill.SkillConnectionsGroupConfig;
 import net.puffish.skillsmod.config.skill.SkillsConfig;
-import net.puffish.skillsmod.reward.builtin.PerLevelRewardsReward;
+import net.puffish.skillsmod.reward.builtin.AddonPerLevelReward;
 import net.puffish.skillsmod.util.PointSources;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,10 +33,10 @@ public class CategoryDataTest {
     @Test
     public void testPerLevelRewardExtendsMaxLevel() throws Exception {
         Map<Integer, List<SkillRewardConfig>> levelRewards = new HashMap<>();
-        Constructor<PerLevelRewardsReward> ctor = PerLevelRewardsReward.class.getDeclaredConstructor(Map.class, String.class, int.class, int.class);
+        Constructor<AddonPerLevelReward> ctor = AddonPerLevelReward.class.getDeclaredConstructor(Map.class, String.class, int.class, int.class);
         ctor.setAccessible(true);
-        PerLevelRewardsReward plr = ctor.newInstance(levelRewards, "skill", 3, 0);
-        SkillRewardConfig rewardConfig = new SkillRewardConfig(PerLevelRewardsReward.ID, plr);
+        AddonPerLevelReward plr = ctor.newInstance(levelRewards, "skill", 3, 0);
+        SkillRewardConfig rewardConfig = new SkillRewardConfig(AddonPerLevelReward.ID, plr);
 
         SkillDefinitionConfig definition = new SkillDefinitionConfig(
                 "def",
@@ -90,10 +90,10 @@ public class CategoryDataTest {
     @Test
     public void testPerLevelRewardCostsPointsPerLevel() throws Exception {
         Map<Integer, List<SkillRewardConfig>> levelRewards = new HashMap<>();
-        Constructor<PerLevelRewardsReward> ctor = PerLevelRewardsReward.class.getDeclaredConstructor(Map.class, String.class, int.class, int.class);
+        Constructor<AddonPerLevelReward> ctor = AddonPerLevelReward.class.getDeclaredConstructor(Map.class, String.class, int.class, int.class);
         ctor.setAccessible(true);
-        PerLevelRewardsReward plr = ctor.newInstance(levelRewards, "skill", 1, 2);
-        SkillRewardConfig rewardConfig = new SkillRewardConfig(PerLevelRewardsReward.ID, plr);
+        AddonPerLevelReward plr = ctor.newInstance(levelRewards, "skill", 1, 2);
+        SkillRewardConfig rewardConfig = new SkillRewardConfig(AddonPerLevelReward.ID, plr);
 
         SkillDefinitionConfig definition = new SkillDefinitionConfig(
                 "def",

--- a/Fabric/src/main/java/net/puffish/skillsmod/main/FabricMain.java
+++ b/Fabric/src/main/java/net/puffish/skillsmod/main/FabricMain.java
@@ -17,6 +17,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.GameRules;
 import net.puffish.skillsmod.SkillsMod;
+import net.puffish.skillsmod.reward.builtin.AddonPerLevelReward;
 import net.puffish.skillsmod.mixin.GameRulesAccessor;
 import net.puffish.skillsmod.network.InPacket;
 import net.puffish.skillsmod.network.OutPacket;
@@ -33,13 +34,15 @@ public class FabricMain implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		SkillsMod.setup(
-				FabricLoader.getInstance().getConfigDir(),
-				new ServerRegistrarImpl(),
-				new ServerEventReceiverImpl(),
-				new ServerPacketSenderImpl(),
-				new ServerPlatformImpl()
-		);
+                SkillsMod.setup(
+                                FabricLoader.getInstance().getConfigDir(),
+                                new ServerRegistrarImpl(),
+                                new ServerEventReceiverImpl(),
+                                new ServerPacketSenderImpl(),
+                                new ServerPlatformImpl()
+                );
+
+                AddonPerLevelReward.register();
 
 	}
 

--- a/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
+++ b/Forge/src/main/java/net/puffish/skillsmod/main/ForgeMain.java
@@ -28,6 +28,7 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.server.ServerLifecycleHooks;
 import net.puffish.skillsmod.SkillsMod;
 import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.reward.builtin.AddonPerLevelReward;
 import net.puffish.skillsmod.mixin.GameRulesAccessor;
 import net.puffish.skillsmod.network.InPacket;
 import net.puffish.skillsmod.network.OutPacket;
@@ -56,14 +57,16 @@ public class ForgeMain {
 		forgeEventBus.addListener(this::onOnDatapackSyncEvent);
 		forgeEventBus.addListener(this::onRegisterCommands);
 
-		SkillsMod.setup(
-				FMLPaths.CONFIGDIR.get(),
-				new ServerRegistrarImpl(),
-				new ServerEventReceiverImpl(),
-				new ServerPacketSenderImpl(),
-				new ServerPlatformImpl()
-		);
-	}
+                SkillsMod.setup(
+                                FMLPaths.CONFIGDIR.get(),
+                                new ServerRegistrarImpl(),
+                                new ServerEventReceiverImpl(),
+                                new ServerPacketSenderImpl(),
+                                new ServerPlatformImpl()
+                );
+
+                AddonPerLevelReward.register();
+        }
 
 	private void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
 		if (event.getEntity() instanceof ServerPlayerEntity serverPlayer) {


### PR DESCRIPTION
## Summary
- rename per-level reward class to AddonPerLevelReward and document its config keys
- register the addon reward during Fabric and Forge initialization
- drop old built-in registration

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6899e6e1892c8327b2e74fa6c2febd68