### PR TITLE
Cache players for skill unlock/lock events

### DIFF
--- a/Common/src/main/java/net/bluelotuscoding/skillleveling/data/SkillLevelingDataManager.java
+++ b/Common/src/main/java/net/bluelotuscoding/skillleveling/data/SkillLevelingDataManager.java
@@ -73,4 +73,32 @@ public class SkillLevelingDataManager {
             playerData.remove(categoryId);
         }
     }
+
+    /**
+     * Check if a specific skill level entry exists for a player.
+     */
+    public boolean hasSkillLevel(ServerPlayerEntity player, Identifier categoryId, String skillId) {
+        var playerData = playerSkillLevels.get(player.getUuid());
+        if (playerData == null) {
+            return false;
+        }
+        var categoryData = playerData.get(categoryId);
+        return categoryData != null && categoryData.containsKey(skillId);
+    }
+
+    /**
+     * Remove a specific skill level entry for a player.
+     */
+    public void clearSkillLevel(ServerPlayerEntity player, Identifier categoryId, String skillId) {
+        var playerData = playerSkillLevels.get(player.getUuid());
+        if (playerData != null) {
+            var categoryData = playerData.get(categoryId);
+            if (categoryData != null) {
+                categoryData.remove(skillId);
+                if (categoryData.isEmpty()) {
+                    playerData.remove(categoryId);
+                }
+            }
+        }
+    }
 }

--- a/Common/src/main/java/net/bluelotuscoding/skillleveling/events/SkillEventHandler.java
+++ b/Common/src/main/java/net/bluelotuscoding/skillleveling/events/SkillEventHandler.java
@@ -3,14 +3,21 @@ package net.bluelotuscoding.skillleveling.events;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.puffish.skillsmod.api.SkillsAPI;
-import net.puffish.skillsmod.api.Events;
 import net.bluelotuscoding.skillleveling.SkillLevelingMod;
-import net.bluelotuscoding.skillleveling.rewards.PerLevelRewardsReward;
+import net.puffish.skillsmod.api.Skill;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Event handler that integrates with the Skills mod to provide per-level rewards
  */
 public class SkillEventHandler {
+
+    // Cache of unlocked skills to track which player triggered the event
+    private static final Map<Identifier, Map<String, Set<UUID>>> UNLOCKED_PLAYERS = new ConcurrentHashMap<>();
     
     public static void initialize() {
         // Register event listeners using the correct API
@@ -19,16 +26,64 @@ public class SkillEventHandler {
     }
     
     private static void onSkillUnlock(Identifier categoryId, String skillId) {
-        // Note: The Skills API doesn't provide the player in the event callback
-        // This means we can't directly initialize skill levels here
-        // The skill level initialization will need to happen differently
-        // For now, this is a placeholder for future integration
+        var manager = SkillLevelingMod.getInstance().getSkillLevelingManager();
+        manager.getServer().ifPresent(server -> {
+            var category = SkillsAPI.getCategory(categoryId);
+            if (category.isEmpty()) {
+                return;
+            }
+            var skill = category.get().getSkill(skillId);
+            if (skill.isEmpty()) {
+                return;
+            }
+
+            var cache = UNLOCKED_PLAYERS
+                    .computeIfAbsent(categoryId, id -> new ConcurrentHashMap<>())
+                    .computeIfAbsent(skillId, id -> ConcurrentHashMap.newKeySet());
+
+            for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+                if (!cache.contains(player.getUuid()) && skill.get().getState(player) == Skill.State.UNLOCKED) {
+                    cache.add(player.getUuid());
+                    if (!manager.hasSkillData(player, categoryId, skillId)) {
+                        manager.initializeSkillData(player, categoryId, skillId);
+                    }
+                }
+            }
+        });
     }
-    
+
     private static void onSkillLock(Identifier categoryId, String skillId) {
-        // Note: The Skills API doesn't provide the player in the event callback
-        // This means we can't directly reset skill levels here
-        // The skill level reset will need to happen differently
-        // For now, this is a placeholder for future integration
+        var manager = SkillLevelingMod.getInstance().getSkillLevelingManager();
+        manager.getServer().ifPresent(server -> {
+            var category = SkillsAPI.getCategory(categoryId);
+            if (category.isEmpty()) {
+                return;
+            }
+            var skill = category.get().getSkill(skillId);
+            if (skill.isEmpty()) {
+                return;
+            }
+
+            var skillMap = UNLOCKED_PLAYERS.get(categoryId);
+            if (skillMap == null) {
+                return;
+            }
+            var cache = skillMap.get(skillId);
+            if (cache == null) {
+                return;
+            }
+
+            var iterator = cache.iterator();
+            while (iterator.hasNext()) {
+                var uuid = iterator.next();
+                var player = server.getPlayerManager().getPlayer(uuid);
+                if (player == null || skill.get().getState(player) != Skill.State.UNLOCKED) {
+                    if (player != null) {
+                        manager.clearSkillData(player, categoryId, skillId);
+                    }
+                    iterator.remove();
+                }
+            }
+        });
     }
 }

--- a/Common/src/main/java/net/bluelotuscoding/skillleveling/manager/SkillLevelingManager.java
+++ b/Common/src/main/java/net/bluelotuscoding/skillleveling/manager/SkillLevelingManager.java
@@ -25,6 +25,7 @@ public class SkillLevelingManager {
     private final SkillLevelingDataManager dataManager;
     private final Map<String, LeveledSkill> leveledSkills;
     private final Map<Identifier, Map<String, PerLevelRewardsReward>> perLevelRewardsRewards;
+    private MinecraftServer server;
     
     public SkillLevelingManager() {
         this.dataManager = new SkillLevelingDataManager();
@@ -33,9 +34,10 @@ public class SkillLevelingManager {
     }
     
     public void onServerStarting(MinecraftServer server) {
+        this.server = server;
         // Initialize data storage
         dataManager.initialize(server);
-        
+
         // Load leveled skill configurations
         loadLeveledSkillConfigurations();
     }
@@ -53,6 +55,22 @@ public class SkillLevelingManager {
     public void onPlayerLeave(ServerPlayerEntity player) {
         // Save player skill level data
         dataManager.savePlayerData(player);
+    }
+
+    public Optional<MinecraftServer> getServer() {
+        return Optional.ofNullable(server);
+    }
+
+    public boolean hasSkillData(ServerPlayerEntity player, Identifier categoryId, String skillId) {
+        return dataManager.hasSkillLevel(player, categoryId, skillId);
+    }
+
+    public void initializeSkillData(ServerPlayerEntity player, Identifier categoryId, String skillId) {
+        dataManager.setSkillLevel(player, categoryId, skillId, 1);
+    }
+
+    public void clearSkillData(ServerPlayerEntity player, Identifier categoryId, String skillId) {
+        dataManager.clearSkillLevel(player, categoryId, skillId);
     }
     
     /**


### PR DESCRIPTION
## Summary
- Track server reference and player skill data for unlock/lock events
- Cache unlocked players per skill and initialize or clear level data accordingly
- Add data manager helpers to check and remove stored skill levels

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a339466e6c8327930a10777f55b8aa