### PR TITLE
Persist player skill data across sessions

### DIFF
--- a/Common/src/main/java/net/bluelotuscoding/skillleveling/data/SkillLevelingDataManager.java
+++ b/Common/src/main/java/net/bluelotuscoding/skillleveling/data/SkillLevelingDataManager.java
@@ -1,8 +1,18 @@
 package net.bluelotuscoding.skillleveling.data;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,28 +21,60 @@ import java.util.concurrent.ConcurrentHashMap;
  * Manages persistent data for skill levels across server restarts
  */
 public class SkillLevelingDataManager {
-    
+
     // Map of player UUID -> category -> skill -> level
     private final Map<UUID, Map<Identifier, Map<String, Integer>>> playerSkillLevels;
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private Path dataDir;
     
     public SkillLevelingDataManager() {
         this.playerSkillLevels = new ConcurrentHashMap<>();
     }
     
     public void initialize(MinecraftServer server) {
-        // Initialize data storage - could be file-based or integrated with core mod storage
-        // For now, use in-memory storage
+        dataDir = server.getRunDirectory().toPath().resolve("skill_leveling_data");
+        try {
+            Files.createDirectories(dataDir);
+            Files.list(dataDir)
+                    .filter(Files::isRegularFile)
+                    .forEach(path -> {
+                        String name = path.getFileName().toString();
+                        if (name.endsWith(".json")) {
+                            try {
+                                UUID uuid = UUID.fromString(name.substring(0, name.length() - 5));
+                                playerSkillLevels.put(uuid, readPlayerData(path));
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                            }
+                        }
+                    });
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
-    
+
     public void loadPlayerData(ServerPlayerEntity player) {
-        // Load player skill level data from persistent storage
-        // For now, initialize empty data if not exists
-        playerSkillLevels.computeIfAbsent(player.getUuid(), k -> new ConcurrentHashMap<>());
+        playerSkillLevels.computeIfAbsent(player.getUuid(), uuid -> {
+            Path path = getPlayerPath(uuid);
+            if (Files.exists(path)) {
+                return readPlayerData(path);
+            }
+            return new ConcurrentHashMap<>();
+        });
     }
-    
+
     public void savePlayerData(ServerPlayerEntity player) {
-        // Save player skill level data to persistent storage
-        // Implementation would write to files or database
+        var data = playerSkillLevels.get(player.getUuid());
+        if (data != null) {
+            writePlayerData(player.getUuid(), data);
+        }
+    }
+
+    public void saveAll() {
+        if (dataDir == null) {
+            return;
+        }
+        playerSkillLevels.forEach(this::writePlayerData);
     }
     
     /**
@@ -63,7 +105,7 @@ public class SkillLevelingDataManager {
                 .computeIfAbsent(player.getUuid(), k -> new ConcurrentHashMap<>())
                 .computeIfAbsent(categoryId, k -> new ConcurrentHashMap<>());
     }
-    
+
     /**
      * Reset all skill levels for a player in a category
      */
@@ -71,6 +113,44 @@ public class SkillLevelingDataManager {
         var playerData = playerSkillLevels.get(player.getUuid());
         if (playerData != null) {
             playerData.remove(categoryId);
+        }
+    }
+
+    private Path getPlayerPath(UUID uuid) {
+        return dataDir.resolve(uuid.toString() + ".json");
+    }
+
+    private Map<Identifier, Map<String, Integer>> readPlayerData(Path path) {
+        Map<Identifier, Map<String, Integer>> categories = new ConcurrentHashMap<>();
+        try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            JsonObject root = gson.fromJson(reader, JsonObject.class);
+            for (var entry : root.entrySet()) {
+                Map<String, Integer> skills = new ConcurrentHashMap<>();
+                entry.getValue().getAsJsonObject().entrySet()
+                        .forEach(e -> skills.put(e.getKey(), e.getValue().getAsInt()));
+                categories.put(new Identifier(entry.getKey()), skills);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return categories;
+    }
+
+    private void writePlayerData(UUID uuid, Map<Identifier, Map<String, Integer>> data) {
+        if (dataDir == null) {
+            return;
+        }
+        JsonObject root = new JsonObject();
+        for (var entry : data.entrySet()) {
+            JsonObject skills = new JsonObject();
+            entry.getValue().forEach(skills::addProperty);
+            root.add(entry.getKey().toString(), skills);
+        }
+        Path path = getPlayerPath(uuid);
+        try (Writer writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+            gson.toJson(root, writer);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/Common/src/main/java/net/bluelotuscoding/skillleveling/manager/SkillLevelingManager.java
+++ b/Common/src/main/java/net/bluelotuscoding/skillleveling/manager/SkillLevelingManager.java
@@ -44,6 +44,10 @@ public class SkillLevelingManager {
         // Reload configurations
         loadLeveledSkillConfigurations();
     }
+
+    public void onServerStopping(MinecraftServer server) {
+        dataManager.saveAll();
+    }
     
     public void onPlayerJoin(ServerPlayerEntity player) {
         // Load player skill level data

--- a/Fabric/src/main/java/net/bluelotuscoding/skillleveling/main/FabricMain.java
+++ b/Fabric/src/main/java/net/bluelotuscoding/skillleveling/main/FabricMain.java
@@ -2,6 +2,8 @@ package net.bluelotuscoding.skillleveling.main;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.bluelotuscoding.skillleveling.SkillLevelingMod;
 import net.bluelotuscoding.skillleveling.commands.SkillLevelingCommand;
 
@@ -12,12 +14,25 @@ public class FabricMain implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		SkillLevelingMod.init();
-		
-		// Register commands
-		CommandRegistrationCallback.EVENT.register(
-			(dispatcher, registryAccess, environment) -> 
-				SkillLevelingCommand.register(dispatcher)
-		);
-	}
+                SkillLevelingMod.init();
+
+                // Register commands
+                CommandRegistrationCallback.EVENT.register(
+                        (dispatcher, registryAccess, environment) ->
+                                SkillLevelingCommand.register(dispatcher)
+                );
+
+                ServerLifecycleEvents.SERVER_STARTING.register(server ->
+                        SkillLevelingMod.getInstance().getSkillLevelingManager().onServerStarting(server)
+                );
+                ServerLifecycleEvents.SERVER_STOPPING.register(server ->
+                        SkillLevelingMod.getInstance().getSkillLevelingManager().onServerStopping(server)
+                );
+                ServerPlayConnectionEvents.JOIN.register((handler, sender, server) ->
+                        SkillLevelingMod.getInstance().getSkillLevelingManager().onPlayerJoin(handler.player)
+                );
+                ServerPlayConnectionEvents.DISCONNECT.register((handler, server) ->
+                        SkillLevelingMod.getInstance().getSkillLevelingManager().onPlayerLeave(handler.player)
+                );
+        }
 }

--- a/Forge/src/main/java/net/bluelotuscoding/skillleveling/main/ForgeMain.java
+++ b/Forge/src/main/java/net/bluelotuscoding/skillleveling/main/ForgeMain.java
@@ -1,6 +1,10 @@
 package net.bluelotuscoding.skillleveling.main;
 
 import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedInEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedOutEvent;
+import net.minecraftforge.event.server.ServerStartingEvent;
+import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -8,6 +12,7 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.common.MinecraftForge;
 import net.bluelotuscoding.skillleveling.SkillLevelingMod;
 import net.bluelotuscoding.skillleveling.commands.SkillLevelingCommand;
+import net.minecraft.server.network.ServerPlayerEntity;
 
 /**
  * Forge main class for the Skill Leveling addon
@@ -20,12 +25,36 @@ public class ForgeMain {
 		MinecraftForge.EVENT_BUS.register(this);
 	}
 
-	private void setup(FMLCommonSetupEvent event) {
-		SkillLevelingMod.init();
-	}
-	
-	@SubscribeEvent
-	public void onCommandsRegister(RegisterCommandsEvent event) {
-		SkillLevelingCommand.register(event.getDispatcher());
-	}
+        private void setup(FMLCommonSetupEvent event) {
+                SkillLevelingMod.init();
+        }
+
+        @SubscribeEvent
+        public void onCommandsRegister(RegisterCommandsEvent event) {
+                SkillLevelingCommand.register(event.getDispatcher());
+        }
+
+        @SubscribeEvent
+        public void onServerStarting(ServerStartingEvent event) {
+                SkillLevelingMod.getInstance().getSkillLevelingManager().onServerStarting(event.getServer());
+        }
+
+        @SubscribeEvent
+        public void onServerStopping(ServerStoppingEvent event) {
+                SkillLevelingMod.getInstance().getSkillLevelingManager().onServerStopping(event.getServer());
+        }
+
+        @SubscribeEvent
+        public void onPlayerJoin(PlayerLoggedInEvent event) {
+                if (event.getEntity() instanceof ServerPlayerEntity player) {
+                        SkillLevelingMod.getInstance().getSkillLevelingManager().onPlayerJoin(player);
+                }
+        }
+
+        @SubscribeEvent
+        public void onPlayerLeave(PlayerLoggedOutEvent event) {
+                if (event.getEntity() instanceof ServerPlayerEntity player) {
+                        SkillLevelingMod.getInstance().getSkillLevelingManager().onPlayerLeave(player);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- save skill levels to JSON files per player
- load data on server start/join and save on leave or server stop
- hook Fabric and Forge lifecycle events for persistence

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a33947d2b08327a9a03b1e58781f73