### PR TITLE
Implement SkillsAPI point deductions with tests

### DIFF
--- a/Common/build.gradle.kts
+++ b/Common/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     modImplementation("net.puffish:skillsmod:${project.properties["skills_version"]}")
 
     testImplementation("org.junit.jupiter:junit-jupiter:${project.properties["junit_version"]}")
+    testImplementation("org.mockito:mockito-core:5.2.0")
+    testImplementation("org.mockito:mockito-inline:5.2.0")
 }
 
 tasks.test {

--- a/Common/src/main/java/net/bluelotuscoding/skillleveling/points/SkillPointManager.java
+++ b/Common/src/main/java/net/bluelotuscoding/skillleveling/points/SkillPointManager.java
@@ -3,6 +3,7 @@ package net.bluelotuscoding.skillleveling.points;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.util.PointSources;
 import net.bluelotuscoding.skillleveling.SkillLevelingMod;
 
 /**
@@ -71,9 +72,8 @@ public class SkillPointManager {
         }
         
         var category = categoryOptional.get();
-        // Note: This would need proper integration with the Skills mod point system
-        // The actual implementation would use the Skills mod's point manipulation methods
-        return true; // Placeholder for actual point deduction
+        category.addPoints(player, PointSources.COMMANDS, -pointCost);
+        return true;
     }
     
     /**
@@ -102,8 +102,7 @@ public class SkillPointManager {
         }
         
         var category = categoryOptional.get();
-        // Note: This would need proper integration with the Skills mod point system
-        // The actual implementation would use the Skills mod's point manipulation methods
+        category.addPoints(player, PointSources.COMMANDS, pointRefund);
     }
     
     /**

--- a/Common/src/test/java/net/bluelotuscoding/skillleveling/points/SkillPointManagerTest.java
+++ b/Common/src/test/java/net/bluelotuscoding/skillleveling/points/SkillPointManagerTest.java
@@ -1,0 +1,82 @@
+package net.bluelotuscoding.skillleveling.points;
+
+import net.bluelotuscoding.skillleveling.SkillLevelingMod;
+import net.bluelotuscoding.skillleveling.rewards.PerLevelRewardsReward;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.puffish.skillsmod.api.Category;
+import net.puffish.skillsmod.api.SkillsAPI;
+import net.puffish.skillsmod.util.PointSources;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SkillPointManagerTest {
+    private static final Identifier CATEGORY_ID = new Identifier("test", "category");
+    private static final String SKILL_ID = "skill";
+
+    @BeforeAll
+    public static void setup() {
+        SkillLevelingMod.init();
+        var manager = SkillLevelingMod.getInstance().getSkillLevelingManager();
+        manager.registerPerLevelRewardsReward(CATEGORY_ID, SKILL_ID, createReward(5));
+    }
+
+    private static PerLevelRewardsReward createReward(int pointsPerLevel) {
+        try {
+            var ctor = PerLevelRewardsReward.class.getDeclaredConstructor(
+                    Map.class, String.class, int.class, int.class, Map.class, Map.class, boolean.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance(new HashMap<>(), SKILL_ID, 1, pointsPerLevel, new HashMap<>(), new HashMap<>(), false);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testDeductPointsForLevel() {
+        ServerPlayerEntity player = null;
+        Category category = Mockito.mock(Category.class);
+        AtomicInteger points = new AtomicInteger(10);
+        Mockito.when(category.getPointsLeft(Mockito.any())).thenAnswer(invocation -> points.get());
+        Mockito.doAnswer(invocation -> {
+            points.addAndGet((Integer) invocation.getArgument(2));
+            return null;
+        }).when(category).addPoints(Mockito.any(), Mockito.eq(PointSources.COMMANDS), Mockito.anyInt());
+
+        try (MockedStatic<SkillsAPI> skills = Mockito.mockStatic(SkillsAPI.class)) {
+            skills.when(() -> SkillsAPI.getCategory(CATEGORY_ID)).thenReturn(Optional.of(category));
+
+            boolean result = SkillPointManager.deductPointsForLevel(player, CATEGORY_ID, SKILL_ID, 1);
+
+            Assertions.assertTrue(result);
+            Assertions.assertEquals(5, points.get());
+        }
+    }
+
+    @Test
+    public void testRefundPointsForLevel() {
+        ServerPlayerEntity player = null;
+        Category category = Mockito.mock(Category.class);
+        AtomicInteger points = new AtomicInteger(0);
+        Mockito.doAnswer(invocation -> {
+            points.addAndGet((Integer) invocation.getArgument(2));
+            return null;
+        }).when(category).addPoints(Mockito.any(), Mockito.eq(PointSources.COMMANDS), Mockito.anyInt());
+
+        try (MockedStatic<SkillsAPI> skills = Mockito.mockStatic(SkillsAPI.class)) {
+            skills.when(() -> SkillsAPI.getCategory(CATEGORY_ID)).thenReturn(Optional.of(category));
+
+            SkillPointManager.refundPointsForLevel(player, CATEGORY_ID, SKILL_ID, 1);
+
+            Assertions.assertEquals(5, points.get());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Deduct and refund skill points using `SkillsAPI` with `PointSources.COMMANDS`
- Add unit tests verifying point cost deduction and refunds
- Include Mockito test dependencies

## Testing
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68a33948cc6083279f22576ade12cd6d