### PR TITLE
Add Spanish and Japanese locale files

### DIFF
--- a/Common/src/main/resources/assets/puffish_skill_leveling/lang/en_us.json
+++ b/Common/src/main/resources/assets/puffish_skill_leveling/lang/en_us.json
@@ -1,7 +1,7 @@
 {
   "skillleveling.command.info": "=== Skill Leveling Info ===",
   "skillleveling.command.active": "Multi-level skill progression is active!",
-  "skillleveling.command.check_help": "Use /skillleveling check to see your skill levels",
+  "skillleveling.command.get_help": "Use /skillleveling get to see your skill levels",
   "skillleveling.command.advance_help": "Use /skillleveling advance to advance skill levels",
   "skillleveling.command.levels_header": "=== Your Skill Levels ===",
   "skillleveling.command.gui_available": "Skill level checking is available through the core skills GUI",

--- a/Common/src/main/resources/assets/puffish_skill_leveling/lang/es_mx.json
+++ b/Common/src/main/resources/assets/puffish_skill_leveling/lang/es_mx.json
@@ -1,0 +1,12 @@
+{
+  "skillleveling.command.info": "=== Información de Nivelación de Habilidades ===",
+  "skillleveling.command.active": "¡La progresión de habilidades multinivel está activa!",
+  "skillleveling.command.get_help": "Usa /skillleveling get para ver tus niveles de habilidad",
+  "skillleveling.command.advance_help": "Usa /skillleveling advance para avanzar niveles de habilidad",
+  "skillleveling.command.levels_header": "=== Tus Niveles de Habilidad ===",
+  "skillleveling.command.gui_available": "La revisión de niveles de habilidad está disponible mediante la GUI de habilidades principal",
+  "skillleveling.command.enhanced": "¡Mejorado con progresión multinivel!",
+  "skillleveling.command.needs_params": "El avance de habilidades requiere parámetros específicos de habilidad",
+  "skillleveling.command.use_gui": "Usa la GUI de habilidades principal para interactuar con tus habilidades",
+  "skillleveling.command.player_only": "Este comando solo puede ser usado por jugadores"
+}

--- a/Common/src/main/resources/assets/puffish_skill_leveling/lang/ja_jp.json
+++ b/Common/src/main/resources/assets/puffish_skill_leveling/lang/ja_jp.json
@@ -1,0 +1,12 @@
+{
+  "skillleveling.command.info": "=== スキルレベリング情報 ===",
+  "skillleveling.command.active": "マルチレベルのスキル進行が有効です！",
+  "skillleveling.command.get_help": "/skillleveling get を使用してスキルレベルを確認します",
+  "skillleveling.command.advance_help": "/skillleveling advance を使用してスキルレベルを進めます",
+  "skillleveling.command.levels_header": "=== あなたのスキルレベル ===",
+  "skillleveling.command.gui_available": "スキルレベルの確認はコアスキルGUIから利用できます",
+  "skillleveling.command.enhanced": "マルチレベルの進行で強化されています！",
+  "skillleveling.command.needs_params": "スキルの進行には特定のスキルパラメータが必要です",
+  "skillleveling.command.use_gui": "スキルとやり取りするにはコアスキルGUIを使用してください",
+  "skillleveling.command.player_only": "このコマンドはプレイヤーのみが使用できます"
+}


### PR DESCRIPTION
## Summary
- add Spanish (es_mx) and Japanese (ja_jp) translations for Skill Leveling messages
- update English locale to use `/skillleveling get`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a3395ddf18832794d37434864647fb